### PR TITLE
issue #541: set default locale to English in test

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/i18n/BundleValueMap.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/i18n/BundleValueMap.java
@@ -44,7 +44,7 @@ public class BundleValueMap extends ValueMap<BundleValue> {
      * @return the sorted value map
      */
     public static ValueMap<BundleValue> fromBundle(String mapId, String baseName, Locale locale) {
-        Control control = ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES);
+        Control control = ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES);
         ResourceBundle rb = ResourceBundle.getBundle(baseName, locale, control);
         ArrayList<BundleValue> items = new ArrayList<BundleValue>();
         for (String key : rb.keySet()) {

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPageMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPageMapper.java
@@ -61,7 +61,9 @@ public class NdkPageMapper extends NdkMapper {
 
     public static ResourceBundle getPageTypeLabels(Locale locale) {
         ResourceBundle rb = ResourceBundle.getBundle(
-                BundleName.MODS_PAGE_TYPES.toString(), locale);
+                BundleName.MODS_PAGE_TYPES.toString(),
+                locale,
+                ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES));
         return rb;
     }
 

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/NdkPlugin.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/NdkPlugin.java
@@ -252,7 +252,8 @@ public class NdkPlugin implements DigitalObjectPlugin, HasMetadataHandler<ModsDe
     private ValueMap<? extends LanguageTermDefinition> readLangs(Locale locale) {
         ArrayList<LangTermValue> langs = new ArrayList<LangTermValue>();
         // to read properties file in UTF-8 use PropertyResourceBundle(Reader)
-        Control control = ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES);
+        Control control = ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES);
+
         ResourceBundle rb = ResourceBundle.getBundle(BundleName.LANGUAGES_ISO639_2.toString(), locale, control);
         for (String key : rb.keySet()) {
             LangTermValue lt = new LangTermValue();

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/oldprint/OldPrintPageMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/oldprint/OldPrintPageMapper.java
@@ -35,7 +35,9 @@ public class OldPrintPageMapper extends NdkPageMapper {
 
     public static ResourceBundle getPageTypeLabels(Locale locale) {
         ResourceBundle rb = ResourceBundle.getBundle(
-                BundleName.MODS_OLDPRINT_PAGE_TYPES.toString(), locale);
+                BundleName.MODS_OLDPRINT_PAGE_TYPES.toString(),
+                locale,
+                ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES));
         return rb;
     }
 

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/object/oldprint/OldPrintPageMapperTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/object/oldprint/OldPrintPageMapperTest.java
@@ -23,15 +23,18 @@ import cz.cas.lib.proarc.common.mods.ndk.NdkMapper.Context;
 import cz.cas.lib.proarc.common.mods.ndk.NdkPageMapper.Page;
 import cz.cas.lib.proarc.mods.ModsDefinition;
 import cz.cas.lib.proarc.mods.TypeOfResourceDefinition;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  *
@@ -122,6 +125,8 @@ public class OldPrintPageMapperTest {
 
     @Test
     public void testGetPageTypeLabel() {
+        Locale.setDefault(Locale.ENGLISH);
+
         assertEquals("Front Endpaper", OldPrintPageMapper.getPageTypeLabel("FrontEndpaper", Locale.ENGLISH));
         assertEquals("Přední předsádka", OldPrintPageMapper.getPageTypeLabel("FrontEndpaper", new Locale("cs")));
     }

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/object/oldprint/OldPrintPageMapperTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/object/oldprint/OldPrintPageMapperTest.java
@@ -129,5 +129,10 @@ public class OldPrintPageMapperTest {
 
         assertEquals("Front Endpaper", OldPrintPageMapper.getPageTypeLabel("FrontEndpaper", Locale.ENGLISH));
         assertEquals("Přední předsádka", OldPrintPageMapper.getPageTypeLabel("FrontEndpaper", new Locale("cs")));
+
+        Locale.setDefault(new Locale("cs", "CZ"));
+
+        assertEquals("Front Endpaper", OldPrintPageMapper.getPageTypeLabel("FrontEndpaper", Locale.ENGLISH));
+        assertEquals("Přední předsádka", OldPrintPageMapper.getPageTypeLabel("FrontEndpaper", new Locale("cs")));
     }
 }

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/server/ServerMessages.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/server/ServerMessages.java
@@ -30,7 +30,7 @@ import java.util.ResourceBundle.Control;
  */
 public final class ServerMessages {
 
-    private static final Control CONTROL = Control.getControl(Control.FORMAT_PROPERTIES);
+    private static final Control CONTROL = Control.getNoFallbackControl(Control.FORMAT_PROPERTIES);
 
     public static ServerMessages get(Locale l) {
         return new ServerMessages(l);

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/server/rest/LocalizationResource.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/server/rest/LocalizationResource.java
@@ -89,7 +89,7 @@ public class LocalizationResource {
             localeObj = new Locale(locale);
         }
 
-        Control control = ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES);
+        Control control = ResourceBundle.Control.getNoFallbackControl(ResourceBundle.Control.FORMAT_PROPERTIES);
         ArrayList<Item> result = new ArrayList<Item>();
         for (BundleName bundleName : bundleNames) {
             try {


### PR DESCRIPTION
File missing suffix "_en" was not detected as english resource bundle
without default Locale set to Locale.ENGLISH.