### PR TITLE
issue #533: Možnost měnit velikost oddílů v RDflow

### DIFF
--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/CanvasSizePersistence.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/CanvasSizePersistence.java
@@ -18,8 +18,6 @@ package cz.cas.lib.proarc.webapp.client.widget;
 
 import com.smartgwt.client.util.Offline;
 import com.smartgwt.client.widgets.Canvas;
-import com.smartgwt.client.widgets.events.ResizedEvent;
-import com.smartgwt.client.widgets.events.ResizedHandler;
 
 /**
  *
@@ -27,22 +25,22 @@ import com.smartgwt.client.widgets.events.ResizedHandler;
  */
 public class CanvasSizePersistence {
 
+    public static final String WIDTH = ".width";
+    public static final String HEIGHT = ".height";
+
     private final String dbPrefix;
 
     public CanvasSizePersistence(String dbPrefix, Canvas canvas) {
         this.dbPrefix = dbPrefix;
-        canvas.addResizedHandler(new ResizedHandler() {
-            @Override
-            public void onResized(ResizedEvent resizedEvent) {
-                Offline.put(dbPrefix + ".width", canvas.getWidth());
-                Offline.put(dbPrefix + ".height", canvas.getHeight());
-            }
+        canvas.addResizedHandler(resizedEvent -> {
+            Offline.put(dbPrefix + WIDTH, canvas.getWidth());
+            Offline.put(dbPrefix + HEIGHT, canvas.getHeight());
         });
     }
 
     public Integer getWidth() {
         try {
-            return Integer.valueOf((String) Offline.get(dbPrefix + ".width"));
+            return Integer.valueOf((String) Offline.get(dbPrefix + WIDTH));
         } catch (NumberFormatException e) {
             return null;
         }
@@ -50,7 +48,7 @@ public class CanvasSizePersistence {
 
     public Integer getHeight() {
         try {
-            return Integer.valueOf((String) Offline.get(dbPrefix + ".height"));
+            return Integer.valueOf((String) Offline.get(dbPrefix + HEIGHT));
         } catch (NumberFormatException e) {
             return null;
         }

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/CanvasSizePersistence.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/CanvasSizePersistence.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017 Martin Rumanek
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package cz.cas.lib.proarc.webapp.client.widget;
+
+import com.smartgwt.client.util.Offline;
+import com.smartgwt.client.widgets.Canvas;
+import com.smartgwt.client.widgets.events.ResizedEvent;
+import com.smartgwt.client.widgets.events.ResizedHandler;
+
+/**
+ *
+ * @author Martin Rumanek
+ */
+public class CanvasSizePersistence {
+
+    private final String dbPrefix;
+
+    public CanvasSizePersistence(String dbPrefix, Canvas canvas) {
+        this.dbPrefix = dbPrefix;
+        canvas.addResizedHandler(new ResizedHandler() {
+            @Override
+            public void onResized(ResizedEvent resizedEvent) {
+                Offline.put(dbPrefix + ".width", canvas.getWidth());
+                Offline.put(dbPrefix + ".height", canvas.getHeight());
+            }
+        });
+    }
+
+    public Integer getWidth() {
+        try {
+            return Integer.valueOf((String) Offline.get(dbPrefix + ".width"));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public Integer getHeight() {
+        try {
+            return Integer.valueOf((String) Offline.get(dbPrefix + ".height"));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+}

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobFormView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobFormView.java
@@ -413,7 +413,7 @@ public class WorkflowJobFormView implements Refreshable {
     }
 
     private Widget createMaterialList() {
-        materialView = new WorkflowMaterialView(i18n, true);
+        materialView = new WorkflowMaterialView(i18n, true, this.getClass().getSimpleName());
         return materialView.getWidget();
     }
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobFormView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobFormView.java
@@ -90,6 +90,8 @@ public class WorkflowJobFormView implements Refreshable {
     private final ActionSource actionSource = new ActionSource(this);
     private Action editTaskAction;
 
+    public static final String VIEW_NAME = "WorkflowJobFormView";
+
     public WorkflowJobFormView(ClientMessages i18n) {
         this.i18n = i18n;
         this.widget = createMainLayout();
@@ -413,7 +415,7 @@ public class WorkflowJobFormView implements Refreshable {
     }
 
     private Widget createMaterialList() {
-        materialView = new WorkflowMaterialView(i18n, true, this.getClass().getSimpleName());
+        materialView = new WorkflowMaterialView(i18n, true, VIEW_NAME);
         return materialView.getWidget();
     }
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobFormView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobFormView.java
@@ -70,6 +70,7 @@ import cz.cas.lib.proarc.webapp.client.ds.WorkflowProfileDataSource;
 import cz.cas.lib.proarc.webapp.client.ds.WorkflowTaskDataSource;
 import cz.cas.lib.proarc.webapp.client.presenter.WorkflowJobsEditor;
 import cz.cas.lib.proarc.webapp.client.presenter.WorkflowManaging.WorkflowJobPlace;
+import cz.cas.lib.proarc.webapp.client.widget.CanvasSizePersistence;
 import cz.cas.lib.proarc.webapp.client.widget.ListGridPersistance;
 
 /**
@@ -237,6 +238,10 @@ public class WorkflowJobFormView implements Refreshable {
         jobForm.setColWidths("*", "*", "*");
         jobForm.setTitleOrientation(TitleOrientation.TOP);
         jobForm.setItemHoverWidth(300);
+        jobForm.setShowResizeBar(true);
+
+        CanvasSizePersistence sizePersistence = new CanvasSizePersistence("WorkflowJobFormView.form", jobForm);
+        jobForm.setHeight(sizePersistence.getHeight());
 
         SelectItem owner = new SelectItem(WorkflowJobDataSource.FIELD_OWNER);
         owner.setOptionDataSource(UserDataSource.getInstance());
@@ -249,6 +254,8 @@ public class WorkflowJobFormView implements Refreshable {
         note.setStartRow(true);
         note.setColSpan("*");
         note.setWidth("*");
+        note.setMinHeight(50);
+        note.setHeight("*");
 
         // title tooltip is broken in SmartGWT 4.0
         final FormItemIcon jobHelpIcon = new FormItemIcon();
@@ -304,6 +311,8 @@ public class WorkflowJobFormView implements Refreshable {
         taskView.setCanSort(false);
         taskView.setDataFetchMode(FetchMode.BASIC);
         taskView.setGenerateDoubleClickOnEnter(true);
+        taskView.setShowResizeBar(true);
+        taskView.setResizeBarTarget("next");
         ListGridPersistance taskViewPersistance = new ListGridPersistance("WorkflowJobFormView.taskList", taskView);
 
         ResultSet rs = new ResultSet();

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowJobView.java
@@ -57,6 +57,7 @@ import cz.cas.lib.proarc.webapp.client.ds.UserDataSource;
 import cz.cas.lib.proarc.webapp.client.ds.WorkflowJobDataSource;
 import cz.cas.lib.proarc.webapp.client.ds.WorkflowProfileDataSource;
 import cz.cas.lib.proarc.webapp.client.presenter.WorkflowJobsEditor;
+import cz.cas.lib.proarc.webapp.client.widget.CanvasSizePersistence;
 import cz.cas.lib.proarc.webapp.client.widget.ListGridPersistance;
 import cz.cas.lib.proarc.webapp.client.widget.StatusView;
 import cz.cas.lib.proarc.webapp.shared.rest.WorkflowResourceApi;
@@ -192,6 +193,10 @@ public class WorkflowJobView implements Refreshable {
         left.addMember(createJobsToolbar());
         left.addMember(createJobList());
         left.addMember(createSubjobList());
+        left.setShowResizeBar(true);
+
+        CanvasSizePersistence sizePersistence = new CanvasSizePersistence("WorkflowJobFormView.jobLayout", left);
+        left.setWidth(sizePersistence.getWidth());
 
         HLayout l = new HLayout();
         l.addMember(left);
@@ -302,6 +307,10 @@ public class WorkflowJobView implements Refreshable {
         ListGrid g = new ListGrid();
         subjobGrid = g;
         subjobsPersistance = new ListGridPersistance("WorkflowJobView.subjobList", g);
+
+        CanvasSizePersistence sizePersistence = new CanvasSizePersistence("WorkflowJobView.subjobList", g);
+        g.setHeight(sizePersistence.getHeight());
+
         g.setSelectionType(SelectionStyle.SINGLE);
         g.setCanGroupBy(false);
         g.setDataFetchMode(FetchMode.BASIC);

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowMaterialView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowMaterialView.java
@@ -58,14 +58,16 @@ public class WorkflowMaterialView {
     private ListGrid materialGrid;
     private final Widget widget;
     private final boolean jobMaterial;
+    private String parentName;
 
-    public WorkflowMaterialView(ClientMessages i18n) {
-        this(i18n, false);
+    public WorkflowMaterialView(ClientMessages i18n, String parentName) {
+        this(i18n, false, parentName);
     }
 
-    public WorkflowMaterialView(ClientMessages i18n, boolean jobMaterial) {
+    public WorkflowMaterialView(ClientMessages i18n, boolean jobMaterial, String parentName) {
         this.i18n = i18n;
         this.jobMaterial = jobMaterial;
+        this.parentName = parentName;
         widget = createMaterialList();
     }
 
@@ -121,7 +123,7 @@ public class WorkflowMaterialView {
         materialGrid.setCanGroupBy(false);
         materialGrid.setWrapCells(true);
 
-        CanvasSizePersistence persistence = new CanvasSizePersistence("WorkflowMaterialView.materialList", materialGrid);
+        CanvasSizePersistence persistence = new CanvasSizePersistence(parentName + ".WorkflowMaterialView.materialList", materialGrid);
         materialGrid.setHeight(persistence.getHeight());
 
         materialGrid.setDataSource(WorkflowMaterialDataSource.getInstance(),

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowMaterialView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowMaterialView.java
@@ -45,6 +45,7 @@ import cz.cas.lib.proarc.webapp.client.ds.RestConfig;
 import cz.cas.lib.proarc.webapp.client.ds.WorkflowJobDataSource;
 import cz.cas.lib.proarc.webapp.client.ds.WorkflowMaterialDataSource;
 import cz.cas.lib.proarc.webapp.client.ds.WorkflowTaskDataSource;
+import cz.cas.lib.proarc.webapp.client.widget.CanvasSizePersistence;
 import cz.cas.lib.proarc.webapp.client.widget.ListGridPersistance;
 
 /**
@@ -119,6 +120,10 @@ public class WorkflowMaterialView {
         materialGrid.setCanSort(false);
         materialGrid.setCanGroupBy(false);
         materialGrid.setWrapCells(true);
+
+        CanvasSizePersistence persistence = new CanvasSizePersistence("WorkflowMaterialView.materialList", materialGrid);
+        materialGrid.setHeight(persistence.getHeight());
+
         materialGrid.setDataSource(WorkflowMaterialDataSource.getInstance(),
                 new ListGridField(WorkflowMaterialDataSource.FIELD_PROFILENAME),
                 new ListGridField(WorkflowMaterialDataSource.FIELD_VALUE),

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowTaskFormView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowTaskFormView.java
@@ -535,7 +535,7 @@ public class WorkflowTaskFormView implements Refreshable {
     }
 
     private Widget createMaterialList() {
-        materialView = new WorkflowMaterialView(i18n);
+        materialView = new WorkflowMaterialView(i18n, this.getClass().getSimpleName());
         return materialView.getWidget();
     }
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowTaskFormView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowTaskFormView.java
@@ -94,6 +94,8 @@ public class WorkflowTaskFormView implements Refreshable {
     private ItemChangedHandler itemChangedHandler;
     private final ActionSource actionSource = new ActionSource(this);
 
+    public static final String VIEW_NAME = "WorkflowTaskFormView";
+
     public WorkflowTaskFormView(ClientMessages i18n, WorkflowTasksEditor handler) {
         this.i18n = i18n;
         this.handler = handler;
@@ -535,7 +537,7 @@ public class WorkflowTaskFormView implements Refreshable {
     }
 
     private Widget createMaterialList() {
-        materialView = new WorkflowMaterialView(i18n, this.getClass().getSimpleName());
+        materialView = new WorkflowMaterialView(i18n, VIEW_NAME);
         return materialView.getWidget();
     }
 


### PR DESCRIPTION
Gettry ve třídě CanvasSizePersistence působí trochu divně, ale má to svůj důvod. Třída Offline se chová trochu neočekávatelně, i když vložím do hodnoty Integer (podle javadocu můžu bere Object), tak při získávání explicitní přetypování na Integer vyhodí `Classcastexception`.

Trochu to řeší i issue https://github.com/proarc/proarc/issues/386 - uživatel si může roztáhnout pole s formulářem a naroste mu i poznámka. 

Nevím v čem u poznámky spočíval bug ve Smartgwt 4. Ve SmartGWT 6 se to taky nechová nejlépe - spolu s poznámkou narůstá minimální výška formuláře na úkor ostatních oddílů (v případě opravdu dlouhé pozánky se k nim poté nedostanu).