### PR TITLE
issue #517: add eventType to Premis

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/Const.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/Const.java
@@ -18,7 +18,9 @@
 package cz.cas.lib.proarc.common.export.mets;
 
 import cz.cas.lib.proarc.common.fedora.BinaryEditor;
+import cz.cas.lib.proarc.common.fedora.StringEditor;
 import cz.cas.lib.proarc.common.object.ndk.NdkPlugin;
+import cz.cas.lib.proarc.common.ocr.AltoDatastream;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -91,6 +93,12 @@ public class Const {
     public static final String HASMEMBER = "fedora-rels-ext:hasMember";
     public static final String ISONPAGE = "kramerius:isOnPage";
 
+    public static final String RAW_GRP_ID = "RAW";
+    public static final String MC_GRP_ID = "MC_IMGGRP";
+    public static final String ALTO_GRP_ID = "ALTOGRP";
+    public static final String UC_GRP_ID = "UC_IMGGRP";
+    public static final String TXT_GRP_ID = "TXTGRP";
+
     public static final List<String> PSPElements = new ArrayList<String>();
 
     public final static Map<String, String> typeMap = new HashMap<String, String>();
@@ -144,39 +152,39 @@ public class Const {
         typeNameMap.put(CHAPTER, CHAPTER);
         typeNameMap.put(MONOGRAPH_MULTIPART, MONOGRAPH);
 
-        mandatoryStreams.add("MC_IMGGRP");
-        mandatoryStreams.add("UC_IMGGRP");
-        mandatoryStreams.add("ALTOGRP");
-        mandatoryStreams.add("TXTGRP");
+        mandatoryStreams.add(MC_GRP_ID);
+        mandatoryStreams.add(UC_GRP_ID);
+        mandatoryStreams.add(ALTO_GRP_ID);
+        mandatoryStreams.add(TXT_GRP_ID);
 
         streamMapping = new HashMap<String, List<String>>();
-        streamMapping.put("MC_IMGGRP", new ArrayList<String>());
-        streamMapping.get("MC_IMGGRP").add(BinaryEditor.NDK_ARCHIVAL_ID);
+        streamMapping.put(MC_GRP_ID, new ArrayList<String>());
+        streamMapping.get(MC_GRP_ID).add(BinaryEditor.NDK_ARCHIVAL_ID);
         // streamMapping.get("MC_IMGGRP").add("RAW");
 
-        streamMapping.put("UC_IMGGRP", new ArrayList<String>());
-        streamMapping.get("UC_IMGGRP").add(BinaryEditor.NDK_USER_ID);
+        streamMapping.put(UC_GRP_ID, new ArrayList<String>());
+        streamMapping.get(UC_GRP_ID).add(BinaryEditor.NDK_USER_ID);
         // streamMapping.get("UC_IMGGRP").add("FULL");
 
-        streamMapping.put("ALTOGRP", new ArrayList<String>());
-        streamMapping.get("ALTOGRP").add("ALTO");
+        streamMapping.put(ALTO_GRP_ID, new ArrayList<String>());
+        streamMapping.get(ALTO_GRP_ID).add(AltoDatastream.ALTO_ID);
 
-        streamMapping.put("TXTGRP", new ArrayList<String>());
-        streamMapping.get("TXTGRP").add("TEXT_OCR");
+        streamMapping.put(TXT_GRP_ID, new ArrayList<String>());
+        streamMapping.get(TXT_GRP_ID).add(StringEditor.OCR_ID);
 
         streamMapping.put("TECHMDGRP", new ArrayList<String>());
         streamMapping.get("TECHMDGRP").add("FULL_AMD");
 
-        streamMappingPrefix.put("MC_IMGGRP", "MC");
-        streamMappingPrefix.put("UC_IMGGRP", "UC");
-        streamMappingPrefix.put("ALTOGRP", "ALTO");
-        streamMappingPrefix.put("TXTGRP", "TXT");
+        streamMappingPrefix.put(MC_GRP_ID, "MC");
+        streamMappingPrefix.put(UC_GRP_ID, "UC");
+        streamMappingPrefix.put(ALTO_GRP_ID, "ALTO");
+        streamMappingPrefix.put(TXT_GRP_ID, "TXT");
         streamMappingPrefix.put("TECHMDGRP", "AMD_METS");
 
-        streamMappingFile.put("MC_IMGGRP", "masterCopy");
-        streamMappingFile.put("UC_IMGGRP", "userCopy");
-        streamMappingFile.put("ALTOGRP", "ALTO");
-        streamMappingFile.put("TXTGRP", "TXT");
+        streamMappingFile.put(MC_GRP_ID, "masterCopy");
+        streamMappingFile.put(UC_GRP_ID, "userCopy");
+        streamMappingFile.put(ALTO_GRP_ID, "ALTO");
+        streamMappingFile.put(TXT_GRP_ID, "TXT");
         streamMappingFile.put("TECHMDGRP", "amdSec");
 
         canContainPage.add(Const.ISSUE);
@@ -185,13 +193,17 @@ public class Const {
         canContainPage.add(Const.SUPPLEMENT);
         canContainPage.add(Const.PERIODICAL_VOLUME);
 
-        dataStreamToModel.put("RAW", BinaryEditor.RAW_ID);
-        dataStreamToModel.put("MC_IMGGRP", BinaryEditor.NDK_ARCHIVAL_ID);
-        dataStreamToModel.put("ALTOGRP", "ALTO");
+        dataStreamToModel.put(RAW_GRP_ID, BinaryEditor.RAW_ID);
+        dataStreamToModel.put(MC_GRP_ID, BinaryEditor.NDK_ARCHIVAL_ID);
+        dataStreamToModel.put(ALTO_GRP_ID, AltoDatastream.ALTO_ID);
+        dataStreamToModel.put(UC_GRP_ID, BinaryEditor.NDK_USER_ID);
+        dataStreamToModel.put(TXT_GRP_ID, StringEditor.OCR_ID);
 
-        dataStreamToEvent.put("RAW", "digitization_001");
-        dataStreamToEvent.put("MC_IMGGRP", "MC_creation_001");
-        dataStreamToEvent.put("ALTOGRP", "XML_creation_001");
+        dataStreamToEvent.put(RAW_GRP_ID, "digitization_001");
+        dataStreamToEvent.put(MC_GRP_ID, "MC_creation_001");
+        dataStreamToEvent.put(ALTO_GRP_ID, "XML_creation_001");
+        dataStreamToEvent.put(UC_GRP_ID, "UC_creation_001");
+        dataStreamToEvent.put(TXT_GRP_ID, "TXT_creation_001");
 
     }
 }

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/MetsUtils.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/MetsUtils.java
@@ -612,22 +612,22 @@ public class MetsUtils {
      */
     public static HashMap<String, FileGrp> initFileGroups() {
         FileGrp MCimagesGRP = new FileGrp();
-        MCimagesGRP.setID("MC_IMGGRP");
+        MCimagesGRP.setID(Const.MC_GRP_ID);
         MCimagesGRP.setUSE("Images");
         // mets.getFileSec().getFileGrp().add(MCimagesGRP);
 
         FileGrp UCimageGrp = new FileGrp();
-        UCimageGrp.setID("UC_IMGGRP");
+        UCimageGrp.setID(Const.UC_GRP_ID);
         UCimageGrp.setUSE("Images");
         // mets.getFileSec().getFileGrp().add(UCimageGrp);
 
         FileGrp AltoGRP = new FileGrp();
-        AltoGRP.setID("ALTOGRP");
+        AltoGRP.setID(Const.ALTO_GRP_ID);
         AltoGRP.setUSE("Layout");
         // mets.getFileSec().getFileGrp().add(AltoGRP);
 
         FileGrp TxtGRP = new FileGrp();
-        TxtGRP.setID("TXTGRP");
+        TxtGRP.setID(Const.TXT_GRP_ID);
         TxtGRP.setUSE("Text");
         // mets.getFileSec().getFileGrp().add(TxtGRP);
 
@@ -637,10 +637,10 @@ public class MetsUtils {
         // mets.getFileSec().getFileGrp().add(TechMDGrp);
 
         HashMap<String, FileGrp> fileGrpMap = new HashMap<String, FileGrp>();
-        fileGrpMap.put("UC_IMGGRP", UCimageGrp);
-        fileGrpMap.put("MC_IMGGRP", MCimagesGRP);
-        fileGrpMap.put("ALTOGRP", AltoGRP);
-        fileGrpMap.put("TXTGRP", TxtGRP);
+        fileGrpMap.put(Const.UC_GRP_ID, UCimageGrp);
+        fileGrpMap.put(Const.MC_GRP_ID, MCimagesGRP);
+        fileGrpMap.put(Const.ALTO_GRP_ID, AltoGRP);
+        fileGrpMap.put(Const.TXT_GRP_ID, TxtGRP);
         fileGrpMap.put("TECHMDGRP", TechMDGrp);
         return fileGrpMap;
     }

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/structure/MetsElementVisitor.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/structure/MetsElementVisitor.java
@@ -59,6 +59,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -685,7 +686,7 @@ public class MetsElementVisitor implements IMetsElementVisitor {
         event.setEventDetail(eventDetail);
         EventIdentifierComplexType eventIdentifier = new EventIdentifierComplexType();
         event.setEventIdentifier(eventIdentifier);
-        event.setEventType("derivation");
+        event.setEventType(StringUtils.substringBefore(eventDetail, "/"));
         eventIdentifier.setEventIdentifierType("ProArc_EventID");
         eventIdentifier.setEventIdentifierValue(Const.dataStreamToEvent.get(datastream));
         EventOutcomeInformationComplexType eventInformation = new EventOutcomeInformationComplexType();
@@ -838,22 +839,24 @@ public class MetsElementVisitor implements IMetsElementVisitor {
             amdSec.getTechMD().add(mdSec);
         }
         if ("OBJ_002".equals(Id) || ("EVT_002".equals(Id))) {
-            if ((amdSecFileGrpMap.get("MC_IMGGRP") != null) && (amdSecFileGrpMap.get("MC_IMGGRP").getFile().get(0) != null)) {
-                amdSecFileGrpMap.get("MC_IMGGRP").getFile().get(0).getADMID().add(mdSec);
+            if ((amdSecFileGrpMap.get(Const.MC_GRP_ID) != null) && (amdSecFileGrpMap.get(Const.MC_GRP_ID).getFile().get(0) != null)) {
+                amdSecFileGrpMap.get(Const.MC_GRP_ID).getFile().get(0).getADMID().add(mdSec);
             }
         }
         if ("OBJ_003".equals(Id) || ("EVT_003".equals(Id))) {
-            if ((amdSecFileGrpMap.get("ALTOGRP") != null) && (amdSecFileGrpMap.get("ALTOGRP").getFile().get(0) != null)) {
-                amdSecFileGrpMap.get("ALTOGRP").getFile().get(0).getADMID().add(mdSec);
+            if ((amdSecFileGrpMap.get(Const.ALTO_GRP_ID) != null) && (amdSecFileGrpMap.get(Const.ALTO_GRP_ID).getFile().get(0) != null)) {
+                amdSecFileGrpMap.get(Const.ALTO_GRP_ID).getFile().get(0).getADMID().add(mdSec);
             }
         }
     }
 
     private void addPremisToAmdSec(AmdSecType amdSec, HashMap<String, FileMD5Info> md5InfosMap, IMetsElement metsElement, HashMap<String, FileGrp> amdSecFileGrpMap) throws MetsExportException {
         HashMap<String, String> toGenerate = new HashMap<String, String>();
-        toGenerate.put("OBJ_001", "RAW");
-        toGenerate.put("OBJ_002", "MC_IMGGRP");
-        toGenerate.put("OBJ_003", "ALTOGRP");
+        toGenerate.put("OBJ_001", Const.RAW_GRP_ID);
+        toGenerate.put("OBJ_002", Const.MC_GRP_ID);
+        toGenerate.put("OBJ_003", Const.ALTO_GRP_ID);
+        toGenerate.put("OBJ_004", Const.UC_GRP_ID);
+        toGenerate.put("OBJ_005", Const.TXT_GRP_ID);
 
         for (String obj : toGenerate.keySet()) {
             String stream = toGenerate.get(obj);
@@ -863,15 +866,21 @@ public class MetsElementVisitor implements IMetsElementVisitor {
             addPremisNodeToMets(getPremisFile(metsElement, stream, md5InfosMap.get(stream)), amdSec, obj, false, amdSecFileGrpMap);
         }
 
-        if (md5InfosMap.get("RAW") != null) {
-            addPremisNodeToMets(getPremisEvent(metsElement, "RAW", md5InfosMap.get("RAW"), "capture/digitization"), amdSec, "EVT_001", true, null);
+        if (md5InfosMap.get(Const.RAW_GRP_ID) != null) {
+            addPremisNodeToMets(getPremisEvent(metsElement, Const.RAW_GRP_ID, md5InfosMap.get(Const.RAW_GRP_ID), "capture/digitization"), amdSec, "EVT_001", true, null);
         }
 
-        if (md5InfosMap.get("MC_IMGGRP") != null) {
-            addPremisNodeToMets(getPremisEvent(metsElement, "MC_IMGGRP", md5InfosMap.get("MC_IMGGRP"), "migration/MC_creation"), amdSec, "EVT_002", true, amdSecFileGrpMap);
+        if (md5InfosMap.get(Const.MC_GRP_ID) != null) {
+            addPremisNodeToMets(getPremisEvent(metsElement, Const.MC_GRP_ID, md5InfosMap.get(Const.MC_GRP_ID), "migration/MC_creation"), amdSec, "EVT_002", true, amdSecFileGrpMap);
         }
-        if (md5InfosMap.get("ALTOGRP") != null) {
-            addPremisNodeToMets(getPremisEvent(metsElement, "ALTOGRP", md5InfosMap.get("ALTOGRP"), "capture/XML_creation"), amdSec, "EVT_003", true, amdSecFileGrpMap);
+        if (md5InfosMap.get(Const.ALTO_GRP_ID) != null) {
+            addPremisNodeToMets(getPremisEvent(metsElement, Const.ALTO_GRP_ID, md5InfosMap.get(Const.ALTO_GRP_ID), "capture/XML_creation"), amdSec, "EVT_003", true, amdSecFileGrpMap);
+        }
+        if(md5InfosMap.get(Const.UC_GRP_ID) != null){
+            addPremisNodeToMets(getPremisEvent(metsElement, Const.UC_GRP_ID, md5InfosMap.get(Const.UC_GRP_ID), "derivation/UC_creation"), amdSec, "EVT_004", true, amdSecFileGrpMap);
+        }
+        if (md5InfosMap.get(Const.TXT_GRP_ID) != null){
+            addPremisNodeToMets(getPremisEvent(metsElement, Const.TXT_GRP_ID, md5InfosMap.get(Const.TXT_GRP_ID), "capture/TXT_creation"), amdSec, "EVT_005", true, amdSecFileGrpMap);
         }
 
         addPremisNodeToMets(getAgent(metsElement), amdSec, "AGENT_001", true, null);
@@ -902,7 +911,7 @@ public class MetsElementVisitor implements IMetsElementVisitor {
      */
     public static void fixMCMix(JHoveOutput jHoveOutputMC, String originalPid, XMLGregorianCalendar mcCreated, String originalFile, PhotometricInterpretation photometricInterpretation) {
         JhoveUtility.insertChangeHistory(jHoveOutputMC.getMix(), mcCreated, originalFile);
-        JhoveUtility.insertObjectIdentifier(jHoveOutputMC.getMix(), originalPid, "MC_IMGGRP");
+        JhoveUtility.insertObjectIdentifier(jHoveOutputMC.getMix(), originalPid, Const.MC_GRP_ID);
         JhoveUtility.addPhotometricInformation(jHoveOutputMC, photometricInterpretation);
         JhoveUtility.addDenominator(jHoveOutputMC);
         JhoveUtility.addOrientation(jHoveOutputMC);
@@ -1033,21 +1042,21 @@ public class MetsElementVisitor implements IMetsElementVisitor {
                 }
             }
 
-            if (fileNames.get("MC_IMGGRP") != null) {
-                toGenerate.put("MIX_002", "MC_IMGGRP");
-                String outputFileName = outputFileNames.get("MC_IMGGRP");
+            if (fileNames.get(Const.MC_GRP_ID) != null) {
+                toGenerate.put("MIX_002", Const.MC_GRP_ID);
+                String outputFileName = outputFileNames.get(Const.MC_GRP_ID);
                 if (outputFileName != null) {
                     String originalFile = MetsUtils.xPathEvaluateString(metsElement.getRelsExt(), "*[local-name()='RDF']/*[local-name()='Description']/*[local-name()='importFile']");
                     if (metsElement.getMetsContext().getFedoraClient() != null) {
                         jHoveOutputMC = JhoveUtility.getMixFromFedora(metsElement, MixEditor.NDK_ARCHIVAL_ID);
                     }
                     if (jHoveOutputMC == null) {
-                        jHoveOutputMC = JhoveUtility.getMix(new File(outputFileName), metsElement.getMetsContext(), null, md5InfosMap.get("MC_IMGGRP").getCreated(), originalFile);
+                        jHoveOutputMC = JhoveUtility.getMix(new File(outputFileName), metsElement.getMetsContext(), null, md5InfosMap.get(Const.MC_GRP_ID).getCreated(), originalFile);
                         if (jHoveOutputMC.getMix() == null) {
                             throw new MetsExportException(metsElement.getOriginalPid(), "Unable to generate Mix information for MC image", false, null);
                         }
                     }
-                    fixMCMix(jHoveOutputMC, metsElement.getOriginalPid(), md5InfosMap.get("MC_IMGGRP").getCreated(), originalFile, photometricInterpretation);
+                    fixMCMix(jHoveOutputMC, metsElement.getOriginalPid(), md5InfosMap.get(Const.MC_GRP_ID).getCreated(), originalFile, photometricInterpretation);
                 }
             }
 
@@ -1070,15 +1079,15 @@ public class MetsElementVisitor implements IMetsElementVisitor {
                                 md5InfosMap.get(streamName).setFormatVersion(jHoveOutputRaw.getFormatVersion());
                             }
                         }
-                    } else if (("MC_IMGGRP".equals(streamName)) && (md5InfosMap.get("MC_IMGGRP") != null)) {
+                    } else if ((Const.MC_GRP_ID.equals(streamName)) && (md5InfosMap.get(Const.MC_GRP_ID) != null)) {
                         if (jHoveOutputMC != null) {
                             mixNode = jHoveOutputMC.getMixNode();
                             if (md5InfosMap.get(streamName) != null) {
                                 md5InfosMap.get(streamName).setFormatVersion(jHoveOutputMC.getFormatVersion());
                             }
                             if (mixNode != null) {
-                                if ((amdSecFileGrpMap.get("MC_IMGGRP") != null) && (amdSecFileGrpMap.get("MC_IMGGRP").getFile().get(0) != null)) {
-                                    amdSecFileGrpMap.get("MC_IMGGRP").getFile().get(0).getADMID().add(mdSec);
+                                if ((amdSecFileGrpMap.get(Const.MC_GRP_ID) != null) && (amdSecFileGrpMap.get(Const.MC_GRP_ID).getFile().get(0) != null)) {
+                                    amdSecFileGrpMap.get(Const.MC_GRP_ID).getFile().get(0).getADMID().add(mdSec);
                                 }
                             }
                         }
@@ -1097,12 +1106,12 @@ public class MetsElementVisitor implements IMetsElementVisitor {
             }
 
             if (rawFile != null) {
-                outputFileNames.remove("RAW");
+                outputFileNames.remove(Const.RAW_GRP_ID);
                 rawFile.delete();
             }
 
-            if (outputFileNames.get("ALTOGRP") != null) {
-                File altoFile = new File(outputFileNames.get("ALTOGRP"));
+            if (outputFileNames.get(Const.ALTO_GRP_ID) != null) {
+                File altoFile = new File(outputFileNames.get(Const.ALTO_GRP_ID));
                 if (altoFile.exists()) {
                     Schema altoSchema;
                     try {
@@ -1115,7 +1124,7 @@ public class MetsElementVisitor implements IMetsElementVisitor {
                     } catch (Exception exSax) {
                         throw new MetsExportException(metsElement.getOriginalPid(), "Invalid ALTO", false, exSax);
                     }
-                    md5InfosMap.get("ALTOGRP").setFormatVersion("2.0");
+                    md5InfosMap.get(Const.ALTO_GRP_ID).setFormatVersion("2.0");
                 }
             }
 
@@ -1338,7 +1347,7 @@ public class MetsElementVisitor implements IMetsElementVisitor {
                 Fptr fptr = new Fptr();
                 fptr.setFILEID(fileType);
                 pageDiv.getFptr().add(fptr);
-                if ("ALTOGRP".equals(streamName)) {
+                if (Const.ALTO_GRP_ID.equals(streamName)) {
                     metsElement.setAltoFile(fileType);
                 }
             } else {

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/export/mets/MetsUtilsTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/export/mets/MetsUtilsTest.java
@@ -55,7 +55,7 @@ public class MetsUtilsTest {
      *
      */
     private void initTestElements() {
-        MetsExportTestElement monografieTestElement = new MetsExportTestElement("monograph", "monograph", 6, 21, 4, "Monograph", "1ccbf6c5-b22c-4d89-b42e-8cd14101a737.xml");
+        MetsExportTestElement monografieTestElement = new MetsExportTestElement("monograph", "monograph", 6, 32, 4, "Monograph", "1ccbf6c5-b22c-4d89-b42e-8cd14101a737.xml");
         this.testElements.add(monografieTestElement);
         MetsExportTestElement periodikumTestElement = new MetsExportTestElement("periodikum", "periodikum", 42, 323, 5, "Periodical", "3733b6e3-61ab-42fc-a437-964d143acc45.xml");
         this.testElements.add(periodikumTestElement);

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/export/mets/NdkExportTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/export/mets/NdkExportTest.java
@@ -97,7 +97,7 @@ public class NdkExportTest {
         Mets mets = (Mets) unmarshallerMets.unmarshal(amdSecFile);
         assertEquals("PAGE_0001", mets.getAmdSec().get(0).getID());
         List<MdSecType> techMDList = mets.getAmdSec().get(0).getTechMD();
-        assertEquals(2, techMDList.size());
+        assertEquals(4, techMDList.size());
         for (MdSecType techMD : techMDList) {
         if ("MIX_002".equals(techMD.getID())) {
             XmlData mixData = techMD.getMdWrap().getXmlData();
@@ -111,35 +111,25 @@ public class NdkExportTest {
                 assertNotNull(mix.getChangeHistory().getImageProcessing().get(0).getDateTimeProcessed().getValue());
             } else
                 if ("OBJ_002".equals(techMD.getID())) {
-                    XmlData premisData = techMD.getMdWrap().getXmlData();
-                    DOMSource premisSource = new DOMSource((Node) premisData.getAny().get(0));
-                cz.cas.lib.proarc.premis.File premisType = PremisUtils.unmarshal(premisSource, cz.cas.lib.proarc.premis.File.class);
-                assertEquals("info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/NDK_ARCHIVAL",
-                        premisType.getObjectIdentifier().get(0).getObjectIdentifierValue());
-                assertEquals("9b0a294cda0508b1a205a57fa66f9568",
-                        premisType.getObjectCharacteristics().get(0).getFixity().get(0).getMessageDigest());
-                assertEquals("ProArc", premisType.getObjectCharacteristics().get(0).getFixity().get(0).getMessageDigestOriginator());
-                assertEquals("derivation", premisType.getRelationship().get(0).getRelationshipType());
-                assertEquals("MC_creation_001",
-                        premisType.getRelationship().get(0).getRelatedEventIdentification().get(0).getRelatedEventIdentifierValue());
-
+                    testObject(techMD, "info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/NDK_ARCHIVAL", "9b0a294cda0508b1a205a57fa66f9568", "MC_creation_001");
+                } else if ("OBJ_004".equals(techMD.getID())) {
+                    testObject(techMD, "info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/NDK_USER", "9b0a294cda0508b1a205a57fa66f9568", "UC_creation_001");
+                } else if ("OBJ_005".equals(techMD.getID())) {
+                    testObject(techMD, "info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/TEXT_OCR", "d41d8cd98f00b204e9800998ecf8427e", "TXT_creation_001");
                 } else {
                 Assert.fail("Unexpected node:" + techMD.getID());
                 }
         }
 
         List<MdSecType> digiProvList = mets.getAmdSec().get(0).getDigiprovMD();
-        assertEquals(2, digiProvList.size());
+        assertEquals(4, digiProvList.size());
         for (MdSecType digiProv : digiProvList) {
             if ("EVT_002".equals(digiProv.getID())) {
-                XmlData premisData = digiProv.getMdWrap().getXmlData();
-                DOMSource premisSource = new DOMSource((Node) premisData.getAny().get(0));
-                EventComplexType premisType = PremisUtils.unmarshal(premisSource, EventComplexType.class);
-                assertEquals("MC_creation_001", premisType.getEventIdentifier().getEventIdentifierValue());
-                assertEquals("migration/MC_creation", premisType.getEventDetail());
-                assertEquals("ProArc_AgentID", premisType.getLinkingAgentIdentifier().get(0).getLinkingAgentIdentifierType());
-                assertEquals("ProArc", premisType.getLinkingAgentIdentifier().get(0).getLinkingAgentIdentifierValue());
-                assertEquals("info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/NDK_ARCHIVAL", premisType.getLinkingObjectIdentifier().get(0).getLinkingObjectIdentifierValue());
+                testEvent(digiProv, "MC_creation_001", "migration", "migration/MC_creation", "info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/NDK_ARCHIVAL");
+            } else if("EVT_004".equals(digiProv.getID())){
+                testEvent(digiProv, "UC_creation_001", "derivation", "derivation/UC_creation", "info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/NDK_USER");
+            } else if ("EVT_005".equals(digiProv.getID())) {
+                testEvent(digiProv, "TXT_creation_001", "capture", "capture/TXT_creation", "info:fedora/uuid:2ff2dd0c-d438-4d95-940f-690ee0f44a4a/TEXT_OCR");
             } else if ("AGENT_001".equals(digiProv.getID())) {
                 XmlData premisData = digiProv.getMdWrap().getXmlData();
                 DOMSource premisSource = new DOMSource((Node) premisData.getAny().get(0));
@@ -155,5 +145,30 @@ public class NdkExportTest {
         assertEquals("PHYSICAL", mets.getStructMap().get(0).getTYPE());
         assertEquals("MONOGRAPH_PAGE", mets.getStructMap().get(0).getDiv().getTYPE());
         assertEquals(3, mets.getStructMap().get(0).getDiv().getFptr().size());
+    }
+
+    /** Tests if the exception is thrown for invalid object mets  */
+    private void testObject(MdSecType techMD, String objectIdentifierValue, String messageDigest, String relatedEventIdentifierValue) {
+        XmlData premisData = techMD.getMdWrap().getXmlData();
+        DOMSource premisSource = new DOMSource((Node) premisData.getAny().get(0));
+        cz.cas.lib.proarc.premis.File premisType = PremisUtils.unmarshal(premisSource, cz.cas.lib.proarc.premis.File.class);
+        assertEquals(objectIdentifierValue, premisType.getObjectIdentifier().get(0).getObjectIdentifierValue());
+        assertEquals(messageDigest, premisType.getObjectCharacteristics().get(0).getFixity().get(0).getMessageDigest());
+        assertEquals("ProArc", premisType.getObjectCharacteristics().get(0).getFixity().get(0).getMessageDigestOriginator());
+        assertEquals("derivation", premisType.getRelationship().get(0).getRelationshipType());
+        assertEquals(relatedEventIdentifierValue, premisType.getRelationship().get(0).getRelatedEventIdentification().get(0).getRelatedEventIdentifierValue());
+    }
+
+    /** Tests if the exception is thrown for invalid event mets  */
+    private void testEvent(MdSecType digiProv, String eventIdentifierValue, String eventType, String eventDetail, String linkingObjectIdentifierValue){
+        XmlData premisData = digiProv.getMdWrap().getXmlData();
+        DOMSource premisSource = new DOMSource((Node) premisData.getAny().get(0));
+        EventComplexType premisType = PremisUtils.unmarshal(premisSource, EventComplexType.class);
+        assertEquals(eventIdentifierValue, premisType.getEventIdentifier().getEventIdentifierValue());
+        assertEquals(eventType, premisType.getEventType());
+        assertEquals(eventDetail, premisType.getEventDetail());
+        assertEquals("ProArc_AgentID", premisType.getLinkingAgentIdentifier().get(0).getLinkingAgentIdentifierType());
+        assertEquals("ProArc", premisType.getLinkingAgentIdentifier().get(0).getLinkingAgentIdentifierValue());
+        assertEquals(linkingObjectIdentifierValue, premisType.getLinkingObjectIdentifier().get(0).getLinkingObjectIdentifierValue());
     }
 }


### PR DESCRIPTION
Podle #517  přidány události, které se zapisují do amdSec při exportu.

Vychází ze standardu http://www.ndk.cz/standardy-digitalizace/DMFperiodika_16.pdf na straně 61.