### PR TITLE
issue #587: Add authority gmd to element <mods:form>

### DIFF
--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
@@ -320,7 +320,10 @@ public final class NdkCartographicForm {
                     // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
                     // @type
                     // XXX autofill "marcform"
-                    .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.TEXT).setWidth("200").setDefaultValue("marcform").createField())
+                    .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                            .addMapValue("marcform", "marcform")
+                            .addMapValue("gmd", "gmd")
+                    .createField()) //authority
                     .addField(new FieldBuilder("value").setTitle("Form - M").setMaxOccurrences(1)
                         .setType(Field.COMBO).setRequired(true).setHint("form").setDefaultValue("print")
                         .setHint("Údaje o fyzické podobě dokumentu, např. print, electronic, microfilm apod."

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
@@ -214,6 +214,7 @@ public final class NdkChapterForm {
                     // XXX autofill "marcform"
                     .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO).setDefaultValue("marcform")
                         .addMapValue("marcform", "marcform")
+                        .addMapValue("gmd", "gmd")
                     .createField()) // authority
                     .addField(new FieldBuilder("value").setTitle("Form - R").setMaxOccurrences(1).setType(Field.COMBO)
                         .setHint("Údaje o fyzické podobě dokumentu, např. print, electronic, microfilm apod."

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographSupplementForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographSupplementForm.java
@@ -353,6 +353,7 @@ public final class NdkMonographSupplementForm {
                     // @type
                     .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
                         .addMapValue("marcform", "marcform")
+                        .addMapValue("gmd", "gmd")
                     .createField()) // authority
                     .addField(new FieldBuilder("value").setTitle("Form - M").setMaxOccurrences(1)
                         .setType(Field.COMBO).setRequired(true).setHint("form")

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographVolumeForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographVolumeForm.java
@@ -365,6 +365,7 @@ public final class NdkMonographVolumeForm {
                     // XXX autofill "marcform"
                     .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
                         .addMapValue("marcform", "marcform")
+                        .addMapValue("gmd", "gmd")
                     .createField()) // authority
                     .addField(new FieldBuilder("value").setTitle("Form - M").setMaxOccurrences(1)
                         .setType(Field.COMBO).setRequired(true).setHint("form")

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
@@ -321,6 +321,7 @@ public final class NdkPeriodicalForm {
                     // XXX autofill "marcform"
                     .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
                         .addMapValue("marcform", "marcform")
+                        .addMapValue("gmd", "gmd")
                     .createField()) // authority
                     .addField(new FieldBuilder("value").setTitle("Form - M").setMaxOccurrences(1)
                         .setType(Field.COMBO).setRequired(true).setHint("form").setDefaultValue("print")

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalSupplementForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalSupplementForm.java
@@ -361,6 +361,7 @@ public final class NdkPeriodicalSupplementForm {
                     // XXX autofill "marcform"
                     .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
                         .addMapValue("marcform", "marcform")
+                        .addMapValue("gmd", "gmd")
                     .createField()) // authority
                     .addField(new FieldBuilder("value").setTitle("Form - M").setMaxOccurrences(1)
                         .setType(Field.COMBO).setRequired(true).setHint("form").setDefaultValue("print")

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPictureForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPictureForm.java
@@ -201,6 +201,31 @@ public final class NdkPictureForm {
                 // scriptTerm
         .createField()); // language
 
+        modsFields.add(
+            // physicalDescription, physicalDescriptionDefinition
+            new FieldBuilder("physicalDescription").setTitle("Physical Description - R").setMaxOccurrences(10)
+                    .setHint("Obsahuje údaje o fyzickém popisu vnitřní části;" +
+                            "<p>určeno spíše pro články než pro obrazy.")
+                    // form, formDefinition extends stringPlusLanguagePlusAuthority
+                    .addField(new FieldBuilder("form").setTitle("Form - R").setMaxOccurrences(1)
+                            // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
+                            // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                            // @type
+                            // XXX autofill "marcform"
+                            .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO)
+                                    .addMapValue("marcform", "marcform")
+                                    .addMapValue("gmd", "gmd")
+                                    .createField()) // authority
+                            .addField(new FieldBuilder("value").setTitle("Form - R").setMaxOccurrences(1).setType(Field.TEXT)
+                                    .setHint("Údaje o fyzické podobě vnitřní části" +
+                                            "<p>např. print, electronic apod.")
+                                    .createField()) // value
+                            .createField()) // form
+                    // reformattingQuality
+                    // internetMediaType
+                    // digitalOrigin
+                    // extent, stringPlusLanguagePlusSupplied
+                    .createField()); // physicalDescription
         // physicalDescription, physicalDescriptionDefinition
 
         // abstract, abstractDefinition extends stringPlusLanguage

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkSheetMusicForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkSheetMusicForm.java
@@ -321,6 +321,7 @@ public final class NdkSheetMusicForm {
                     // XXX autofill "marcform"
                     .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
                         .addMapValue("marcform", "marcform")
+                        .addMapValue("gmd", "gmd")
                     .createField()) // authority
                     .addField(new FieldBuilder("value").setTitle("Form - M").setMaxOccurrences(1)
                         .setType(Field.COMBO).setRequired(true).setHint("form")


### PR DESCRIPTION
Podle #587 přidána možná hodnota “gmd” u atributu authority elementu <mods:form> v sekci Physical Description

Ve specifikaci https://docs.google.com/document/d/1cWvwfk9bVpTGfeSwQOKfDQlbIyEkJEL-LcMU6bmQL1A/edit#heading=h.30j0zll bod 1.