### PR TITLE
issue #588: Add <name> to Ndk Periodical

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalMapper.java
@@ -177,6 +177,7 @@ public class NdkPeriodicalMapper extends NdkMapper {
             addStringPlusLanguage(dc.getDescriptions(), titleInfo.getPartNumber());
             addStringPlusLanguage(dc.getDescriptions(), titleInfo.getPartName());
         }
+        addName(mods.getName(), dc.getCreators());
         for (GenreDefinition genre : mods.getGenre()) {
             addElementType(dc.getTypes(), genre.getValue());
         }

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapper.java
@@ -71,6 +71,7 @@ public final class NdkPeriodicalVolumeMapper extends NdkMapper {
         if (dateIssued == null) {
             dc.getDates().add(new ElementType(dateIssued, null));
         }
+        addName(mods.getName(), dc.getCreators());
         dc.getTypes().add(new ElementType(GENRE, null));
         return dc;
     }

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalMapperTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalMapperTest.java
@@ -170,6 +170,11 @@ public class NdkPeriodicalMapperTest {
                 + "<titleInfo>"
                     + "<title>T2</title><subTitle>S2</subTitle>"
                 + "</titleInfo>"
+                + "<name usage = 'primary' type='personal'>"
+                + "<namePart type='family'>Novotny</namePart>"
+                + "<namePart type='given'>Tomas</namePart>"
+                + "<namePart type='date'>12.9.1999</namePart>"
+                + "<role><roleTerm>cre</roleTerm></role></name>"
                 + "</mods>";
         ModsDefinition mods = ModsUtils.unmarshalModsType(new StreamSource(new StringReader(xml)));
         NdkPeriodicalMapper mapper = new NdkPeriodicalMapper();
@@ -180,6 +185,7 @@ public class NdkPeriodicalMapperTest {
         assertEquals("T2: S2", result.getTitles().get(1).getValue());
         assertEquals("PNum1", result.getDescriptions().get(0).getValue());
         assertEquals("PNam1", result.getDescriptions().get(1).getValue());
+        assertEquals("Novotny, Tomas, 12.9.1999", result.getCreators().get(0).getValue());
 
     }
 

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapperTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapperTest.java
@@ -21,18 +21,16 @@ import cz.cas.lib.proarc.common.mods.ndk.NdkMapper.Context;
 import cz.cas.lib.proarc.mods.IdentifierDefinition;
 import cz.cas.lib.proarc.mods.ModsDefinition;
 import cz.cas.lib.proarc.oaidublincore.OaiDcType;
+import java.io.StringReader;
+import java.util.List;
+import javax.xml.transform.stream.StreamSource;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import javax.xml.transform.stream.StreamSource;
-import java.io.StringReader;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  *

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapperTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapperTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2014 Lukas Sykora
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package cz.cas.lib.proarc.common.mods.ndk;
+
+import cz.cas.lib.proarc.common.mods.ModsUtils;
+import cz.cas.lib.proarc.common.mods.ndk.NdkMapper.Context;
+import cz.cas.lib.proarc.mods.IdentifierDefinition;
+import cz.cas.lib.proarc.mods.ModsDefinition;
+import cz.cas.lib.proarc.oaidublincore.OaiDcType;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.xml.transform.stream.StreamSource;
+import java.io.StringReader;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Lukas Sykora
+ */
+public class NdkPeriodicalVolumeMapperTest {
+
+    public NdkPeriodicalVolumeMapperTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testCreateMods() {
+        ModsDefinition mods = new ModsDefinition();
+        NdkPeriodicalVolumeMapper mapper = new NdkPeriodicalVolumeMapper();
+        Context ctx = EasyMock.createMock(Context.class);
+        EasyMock.expect(ctx.getPid()).andReturn("uuid:testId").anyTimes();
+        EasyMock.replay(ctx);
+
+        mapper.createMods(mods, ctx);
+        List<IdentifierDefinition> identifiersResult = mods.getIdentifier();
+        assertEquals(1, identifiersResult.size());
+        IdentifierDefinition idResult = identifiersResult.get(0);
+        assertEquals("uuid", idResult.getType());
+        assertEquals("testId", idResult.getValue());
+
+        assertEquals(1, mods.getGenre().size());
+        assertEquals("volume", mods.getGenre().get(0).getValue());
+    }
+
+    @Test
+    public void testCreateDc() {
+        String xml = "<mods version='3.5' xmlns='http://www.loc.gov/mods/v3'>"
+                + "<titleInfo>"
+                + "<nonSort>NS1</nonSort><title>T1</title><subTitle>S1</subTitle><partName>PNam1</partName><partNumber>PNum1</partNumber>"
+                + "</titleInfo>"
+                + "<titleInfo>"
+                + "<title>T2</title><subTitle>S2</subTitle>"
+                + "</titleInfo>"
+                + "<name usage = 'primary' type='personal'>"
+                + "<namePart>Archivist</namePart>"
+                + "<namePart type='family'>Novotny</namePart>"
+                + "<namePart type='given'>Tomas</namePart>"
+                + "<namePart type='date'>12.9.1999</namePart>"
+                + "<role><roleTerm>cre</roleTerm></role></name>"
+                + "</mods>";
+        ModsDefinition mods = ModsUtils.unmarshalModsType(new StreamSource(new StringReader(xml)));
+        NdkPeriodicalMapper mapper = new NdkPeriodicalMapper();
+        NdkMapper.Context ctx = new NdkMapper.Context("uuid:testId");
+
+        OaiDcType result = mapper.createDc(mods, ctx);
+        assertEquals("NS1 T1: S1", result.getTitles().get(0).getValue());
+        assertEquals("T2: S2", result.getTitles().get(1).getValue());
+        assertEquals("PNum1", result.getDescriptions().get(0).getValue());
+        assertEquals("PNam1", result.getDescriptions().get(1).getValue());
+        assertEquals("Archivist Novotny, Tomas, 12.9.1999", result.getCreators().get(0).getValue());
+    }
+}

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapperTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalVolumeMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Lukas Sykora
+ * Copyright (C) 2017 Lukas Sykora
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
@@ -40,6 +40,7 @@ public final class NdkPeriodicalForm {
 //        modsFields.add(new FieldBuilder("version").setTitle("Verze").setMaxOccurrences(1).setType(Field.TEXT).setReadOnly(true).createField());
 
         modsFields.add(titleInfo());
+        modsFields.add(name());
         modsFields.add(typeOfResource());
         modsFields.add(genre());
         modsFields.add(originInfo());
@@ -110,6 +111,72 @@ public final class NdkPeriodicalForm {
                 // nonSort, type="stringPlusLanguage"
                 // titleInfo@attributes: otherType, supplied, altRepGroup, altFormatAttributeGroup, nameTitleGroup, usage, ID, authorityAttributeGroup, xlink:simpleLink, languageAttributeGroup, displayLabel
         .createField(); // titleInfo
+    }
+
+    private Field name() {
+        // name, nameDefinition
+        return new FieldBuilder("name").setMaxOccurrences(10).setTitle("Name - R")
+                .setHint("Údaje o odpovědnosti za titul periodika.")
+                // @ID, @authorityAttributeGroup, @xlinkSimpleLink, @languageAttributeGroup, @displayLabel, @altRepGroup, @nameTitleGroup
+                // @type(personal, corporate, conference, family)
+                .addField(new FieldBuilder("type").setTitle("Type - R").setMaxOccurrences(1).setType(Field.SELECT).setRequired(true)
+                        .setHint("<dl>"
+                                + "<dt>personal</dt><dd>celé jméno osoby</dd>"
+                                + "<dt>corporate</dt><dd>název společnosti, instituce nebo organizace</dd>"
+                                + "<dt>conference</dt><dd>název konference nebo související typ setkání</dd>"
+                                + "<dt>family</dt><dd>rodina/rod</dd>"
+                                + "</dl>")
+                        .addMapValue("personal", "personal")
+                        .addMapValue("corporate", "corporate")
+                        .addMapValue("conference", "conference")
+                        .addMapValue("family", "family")
+                        .createField()) // @type
+                // @usage(fixed="primary")
+                .addField(new FieldBuilder("usage").setTitle("Usage - O").setMaxOccurrences(1).setType(Field.SELECT).setDefaultValue("")
+                        .setHint("Hodnota “primary” pro označení primární autority.")
+                        .addMapValue("", "")
+                        .addMapValue("primary", "primary")
+                        .createField()) // usage
+                // namePart, namePartDefinition extends stringPlusLanguage
+                .addField(new FieldBuilder("namePart").setTitle("Name Parts - R").setMaxOccurrences(5)
+                        // @type(date, family, given, termsOfAddress)
+                        .addField(new FieldBuilder("type").setTitle("Type").setMaxOccurrences(1).setType(Field.SELECT)
+                                .setHint("<dl>"
+                                        + "<dt>date</dt><dd>RA - datum</dd>"
+                                        + "<dt>family</dt><dd>MA -příjmení </dd>"
+                                        + "<dt>given</dt><dd>MA - jméno/křestní jméno</dd>"
+                                        + "<dt>termsOfAddress</dt><dd>RA - tituly a jiná slova nebo čísla související se jménem</dd>"
+                                        + "</dl>")
+                                .addMapValue("date", "date")
+                                .addMapValue("family", "family")
+                                .addMapValue("given", "given")
+                                .addMapValue("termsOfAddress", "termsOfAddress")
+                                .createField()) // @type
+                        // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                        .addField(new FieldBuilder("value").setTitle("Name Part - R").setMaxOccurrences(1)
+                                .setType(Field.TEXT).setRequired(true)
+                                .setHint("Údaje o křestním jméně, příjmení apod."
+                                        + "<p>Nutno vyjádřit pro křestní jméno i příjmení."
+                                        + "<p>Pokud nelze rozlišit křestní jméno a příjmení,"
+                                        + " nepoužije se type a jméno se zaznamená"
+                                        + " v podobě jaké je do jednoho elementu &lt;namePart>"
+                                        + "<p>Pokud známe datum narození a úmrtí autora, vyplnit"
+                                        + " ve tvaru RRRR-RRRR s atributem type=”date”.")
+                                .createField()) // value
+                        .createField()) // namePart
+                // displayForm
+                // etal
+                // affiliation
+                // role, roleDefinition
+                .addField(new FieldBuilder("role").setTitle("Role - R").setMaxOccurrences(5)
+                        .setHint("Specifikace role osoby nebo organizace uvedené v elementu &lt;name>")
+                        // roleTerm, type="roleTermDefinition" extends stringPlusLanguagePlusAuthority
+                        .addField(NdkForms.roleTerm(
+                                "Role Term - R", true, "Authority - M", true, "Type - M", true
+                        )) // roleTerm
+                        .createField()) // role
+                // description
+                .createField(); // name
     }
 
     private Field typeOfResource() {

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalVolumeForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalVolumeForm.java
@@ -39,6 +39,7 @@ public class NdkPeriodicalVolumeForm {
         modsFields.add(titleInfo());
         modsFields.add(genre());
         modsFields.add(originInfo());
+        modsFields.add(name());
         modsFields.add(physicalDescription());
         modsFields.add(identifier());
 
@@ -62,6 +63,72 @@ public class NdkPeriodicalVolumeForm {
                 // nonSort, type="stringPlusLanguage"
                 // titleInfo@attributes: otherType, supplied, altRepGroup, altFormatAttributeGroup, nameTitleGroup, usage, ID, authorityAttributeGroup, xlink:simpleLink, languageAttributeGroup, displayLabel
         .createField(); // titleInfo
+    }
+
+    private Field name() {
+        // name, nameDefinition
+        return new FieldBuilder("name").setMaxOccurrences(10).setTitle("Name - R")
+                .setHint("Údaje o odpovědnosti za titul periodika.")
+                // @ID, @authorityAttributeGroup, @xlinkSimpleLink, @languageAttributeGroup, @displayLabel, @altRepGroup, @nameTitleGroup
+                // @type(personal, corporate, conference, family)
+                .addField(new FieldBuilder("type").setTitle("Type - R").setMaxOccurrences(1).setType(Field.SELECT).setRequired(true)
+                        .setHint("<dl>"
+                                + "<dt>personal</dt><dd>celé jméno osoby</dd>"
+                                + "<dt>corporate</dt><dd>název společnosti, instituce nebo organizace</dd>"
+                                + "<dt>conference</dt><dd>název konference nebo související typ setkání</dd>"
+                                + "<dt>family</dt><dd>rodina/rod</dd>"
+                                + "</dl>")
+                        .addMapValue("personal", "personal")
+                        .addMapValue("corporate", "corporate")
+                        .addMapValue("conference", "conference")
+                        .addMapValue("family", "family")
+                        .createField()) // @type
+                // @usage(fixed="primary")
+                .addField(new FieldBuilder("usage").setTitle("Usage - O").setMaxOccurrences(1).setType(Field.SELECT).setDefaultValue("")
+                        .setHint("Hodnota “primary” pro označení primární autority.")
+                        .addMapValue("", "")
+                        .addMapValue("primary", "primary")
+                        .createField()) // usage
+                // namePart, namePartDefinition extends stringPlusLanguage
+                .addField(new FieldBuilder("namePart").setTitle("Name Parts - R").setMaxOccurrences(5)
+                        // @type(date, family, given, termsOfAddress)
+                        .addField(new FieldBuilder("type").setTitle("Type").setMaxOccurrences(1).setType(Field.SELECT)
+                                .setHint("<dl>"
+                                        + "<dt>date</dt><dd>RA - datum</dd>"
+                                        + "<dt>family</dt><dd>MA -příjmení </dd>"
+                                        + "<dt>given</dt><dd>MA - jméno/křestní jméno</dd>"
+                                        + "<dt>termsOfAddress</dt><dd>RA - tituly a jiná slova nebo čísla související se jménem</dd>"
+                                        + "</dl>")
+                                .addMapValue("date", "date")
+                                .addMapValue("family", "family")
+                                .addMapValue("given", "given")
+                                .addMapValue("termsOfAddress", "termsOfAddress")
+                                .createField()) // @type
+                        // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                        .addField(new FieldBuilder("value").setTitle("Name Part - R").setMaxOccurrences(1)
+                                .setType(Field.TEXT).setRequired(true)
+                                .setHint("Údaje o křestním jméně, příjmení apod."
+                                        + "<p>Nutno vyjádřit pro křestní jméno i příjmení."
+                                        + "<p>Pokud nelze rozlišit křestní jméno a příjmení,"
+                                        + " nepoužije se type a jméno se zaznamená"
+                                        + " v podobě jaké je do jednoho elementu &lt;namePart>"
+                                        + "<p>Pokud známe datum narození a úmrtí autora, vyplnit"
+                                        + " ve tvaru RRRR-RRRR s atributem type=”date”.")
+                                .createField()) // value
+                        .createField()) // namePart
+                // displayForm
+                // etal
+                // affiliation
+                // role, roleDefinition
+                .addField(new FieldBuilder("role").setTitle("Role - R").setMaxOccurrences(5)
+                        .setHint("Specifikace role osoby nebo organizace uvedené v elementu &lt;name>")
+                        // roleTerm, type="roleTermDefinition" extends stringPlusLanguagePlusAuthority
+                        .addField(NdkForms.roleTerm(
+                                "Role Term - R", true, "Authority - M", true, "Type - M", true
+                        )) // roleTerm
+                        .createField()) // role
+                // description
+                .createField(); // name
     }
 
     private Field genre() {


### PR DESCRIPTION
Podle #588  upraven formulář titulu periodika a ročníku tak, aby se dalo zaznamenat mods:name, mods:namePart, mods:role, mods:roleTerm a dc:creator.

Ve specifikaci https://docs.google.com/document/d/1cWvwfk9bVpTGfeSwQOKfDQlbIyEkJEL-LcMU6bmQL1A/edit#heading=h.3znysh7 bod 3.