### PR TITLE
issue #592: Add value "Konspekt" to element <mods:classification>

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkArticleMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkArticleMapper.java
@@ -74,9 +74,7 @@ public class NdkArticleMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
 
         fillRecordInfo(mods);

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkCartographicMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkCartographicMapper.java
@@ -106,9 +106,7 @@ public class NdkCartographicMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
         //  mods/location/physicalLocation@authority="siglaADR"
         List<LocationDefinition> locations = mods.getLocation();

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkChapterMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkChapterMapper.java
@@ -74,9 +74,7 @@ public class NdkChapterMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
 
         fillRecordInfo(mods);

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkMapper.java
@@ -23,6 +23,7 @@ import static cz.cas.lib.proarc.common.mods.ndk.MapperUtils.*;
 import cz.cas.lib.proarc.common.object.DigitalObjectHandler;
 import cz.cas.lib.proarc.common.object.ndk.NdkMetadataHandler.ModsWrapper;
 import cz.cas.lib.proarc.common.object.ndk.NdkPlugin;
+import cz.cas.lib.proarc.mods.ClassificationDefinition;
 import cz.cas.lib.proarc.mods.IdentifierDefinition;
 import cz.cas.lib.proarc.mods.ModsDefinition;
 import cz.cas.lib.proarc.mods.TitleInfoDefinition;
@@ -30,6 +31,7 @@ import cz.cas.lib.proarc.oaidublincore.ElementType;
 import cz.cas.lib.proarc.oaidublincore.OaiDcType;
 import java.io.IOException;
 import java.util.List;
+import org.apache.empire.commons.StringUtils;
 
 /**
  * Subclass to implement transformations of MODS data in NDK flavor
@@ -168,6 +170,16 @@ public abstract class NdkMapper {
             return createTitleString(ti);
         }
         return null;
+    }
+
+    /** Set default Authority value or repair it if needed. */
+    protected void repairAuthorityInClassification(ClassificationDefinition classification){
+        if (classification.getAuthority() == null) {
+            classification.setAuthority("udc");
+        }
+        if (StringUtils.isNotEmpty(classification.getEdition()) && classification.getEdition().equals("Konspekt")){
+            classification.setAuthority("udc"); // edition = "Konspekt" only if authority = "udc"
+        }
     }
 
     public static class Context {

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkMonographSupplementMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkMonographSupplementMapper.java
@@ -47,9 +47,7 @@ public class NdkMonographSupplementMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
     }
 

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkMonographVolumeMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkMonographVolumeMapper.java
@@ -117,9 +117,7 @@ public class NdkMonographVolumeMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
         //  mods/location/physicalLocation@authority="siglaADR"
         List<LocationDefinition> locations = mods.getLocation();

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalMapper.java
@@ -144,9 +144,8 @@ public class NdkPeriodicalMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
+
         }
         //  mods/location/physicalLocation@authority="siglaADR"
         List<LocationDefinition> locations = mods.getLocation();

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalSupplementMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPeriodicalSupplementMapper.java
@@ -46,9 +46,7 @@ public class NdkPeriodicalSupplementMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
     }
 

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPictureMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkPictureMapper.java
@@ -66,9 +66,7 @@ public final class NdkPictureMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
 
         fillRecordInfo(mods);

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkSheetMusicMapper.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/mods/ndk/NdkSheetMusicMapper.java
@@ -106,9 +106,7 @@ public class NdkSheetMusicMapper extends NdkMapper {
         //  mods/classification@authority="udc"
         List<ClassificationDefinition> classifications = mods.getClassification();
         for (ClassificationDefinition classification : classifications) {
-            if (classification.getAuthority() == null) {
-                classification.setAuthority("udc");
-            }
+            repairAuthorityInClassification(classification);
         }
         //  mods/location/physicalLocation@authority="siglaADR"
         List<LocationDefinition> locations = mods.getLocation();

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
@@ -372,11 +372,19 @@ public final class NdkArticleForm {
         return new FieldBuilder("classification").setTitle("Classification - RA").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - RA").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
                 .createField()) // value
         .createField(); // classification
     }

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
@@ -484,11 +484,19 @@ public final class NdkCartographicForm {
         modsFields.add(new FieldBuilder("classification").setTitle("Classification - R").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
                 .createField()) // value
         .createField()); // classification
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
@@ -336,11 +336,19 @@ public final class NdkChapterForm {
         modsFields.add(new FieldBuilder("classification").setTitle("Classification - RA").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - RA").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
                 .createField()) // value
         .createField()); // classification
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographSupplementForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographSupplementForm.java
@@ -502,12 +502,20 @@ public final class NdkMonographSupplementForm {
         return new FieldBuilder("classification").setTitle("Classification - R").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
-                .createField())
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
+                .createField()) // value
         .createField(); // classification
     }
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographVolumeForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographVolumeForm.java
@@ -519,11 +519,19 @@ public final class NdkMonographVolumeForm {
         return new FieldBuilder("classification").setTitle("Classification - R").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
                 .createField()) // value
         .createField(); // classification
     }

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
@@ -491,11 +491,20 @@ public final class NdkPeriodicalForm {
         return new FieldBuilder("classification").setTitle("Classification - R").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField())
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField())
                 // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
                 .createField())
         .createField(); // classification
     }

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalSupplementForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalSupplementForm.java
@@ -511,12 +511,20 @@ public final class NdkPeriodicalSupplementForm {
         return new FieldBuilder("classification").setTitle("Classification - R").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
-                .createField())
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
+                .createField()) // value
         .createField(); // classification
     }
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPictureForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPictureForm.java
@@ -326,12 +326,20 @@ public final class NdkPictureForm {
         modsFields.add(new FieldBuilder("classification").setTitle("Classification - RA").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - RA").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
-                .createField())
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
+                .createField()) // value
         .createField()); // classification
 
         // identifier, identifierDefinition, [0,*]

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkSheetMusicForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkSheetMusicForm.java
@@ -456,11 +456,19 @@ public final class NdkSheetMusicForm {
         modsFields.add(new FieldBuilder("classification").setTitle("Classification - R").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
                 .createField()) // value
         .createField()); // classification
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/bdm/BornDigitalArticleForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/bdm/BornDigitalArticleForm.java
@@ -473,11 +473,19 @@ public final class BornDigitalArticleForm {
         return new FieldBuilder("classification").setTitle("Classification - RA").setMaxOccurrences(10)
                 // stringPlusLanguagePlusAuthority: authorityAttributeGroup: @authority, @authorityURI, @valueURI
                 // autofill "udc"
-                .addField(new FieldBuilder("authority").setTitle("Authority - RA").setMaxOccurrences(1).setType(Field.TEXT).setDefaultValue("udc").createField())
-                // stringPlusLanguage: @lang, @xmlLang, @script, @transliteration
+                .addField(new FieldBuilder("authority").setTitle("Authority - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("udc", "udc")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // authority
+                .addField(new FieldBuilder("edition").setTitle("Edition - M").setMaxOccurrences(1).setType(Field.COMBO)
+                        .addMapValue("", "")
+                        .addMapValue("Konspekt", "Konspekt")
+                .createField()) // edition
                 .addField(new FieldBuilder("value").setMaxOccurrences(1).setType(Field.TEXT)
                     .setHint("Klasifikační údaje věcného třídění podle Mezinárodního"
-                        + " desetinného třídění.<p>Odpovídá poli 080 MARC21.")
+                        + " desetinného třídění. Odpovídá poli 080 MARC21."
+                        + "<p>Klasifikační údaje věcného třídění podle Konspektu."
+                        + " Odpovídá poli 072 $a MARC21.")
                 .createField()) // value
         .createField(); // classification
     }


### PR DESCRIPTION
Podle #592  upraven formulář metadat tak, aby bylo možné zaznamenat do <mods:classification> klasifikační údaje věcného třídění podle Konspektu. 

Současná verze šablony již umí stáhnout tyto pole a údaje se přenesou přímo do formuláře (Vyplní se, jak hodnota Authority, tak i hodnota edition). Zkoušeno na monografii stažené z Alephu ISBN = 978-80-7390-006-9.

Ve specifikaci bod https://docs.google.com/document/d/1cWvwfk9bVpTGfeSwQOKfDQlbIyEkJEL-LcMU6bmQL1A/edit#heading=h.1t3h5sf