### PR TITLE
issue #594: Add value "Konspekt" to element <mods:subject>

### DIFF
--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
@@ -306,7 +306,7 @@ public final class NdkArticleForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - M").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah článku."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
@@ -291,9 +291,10 @@ public final class NdkArticleForm {
         return new FieldBuilder("subject").setTitle("Subject - R").setMaxOccurrences(10)
                 .setHint("Údaje o věcném třídění.")
                 // @ID, @authorityAttributeGroup, @languageAttributeGroup, @xlink:simpleLink, @displayLabel, @altRepGroup, @usage
-                .addField(new FieldBuilder("authority").setTitle("Authority - O").setMaxOccurrences(1).setType(Field.TEXT)
+                .addField(new FieldBuilder("authority").setTitle("Authority - O").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField()) // authority
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -305,7 +306,7 @@ public final class NdkArticleForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - M").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah článku."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
@@ -402,7 +402,7 @@ public final class NdkCartographicForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - R").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah dokumentu."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkCartographicForm.java
@@ -388,6 +388,7 @@ public final class NdkCartographicForm {
                 .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField())
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -401,7 +402,7 @@ public final class NdkCartographicForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - R").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah dokumentu."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
@@ -257,9 +257,10 @@ public final class NdkChapterForm {
         modsFields.add(new FieldBuilder("subject").setTitle("Subject - R").setMaxOccurrences(10)
                 .setHint("Údaje o věcném třídění.")
                 // @ID, @authorityAttributeGroup, @languageAttributeGroup, @xlink:simpleLink, @displayLabel, @altRepGroup, @usage
-                .addField(new FieldBuilder("authority").setTitle("Authority - O").setMaxOccurrences(1).setType(Field.TEXT)
+                .addField(new FieldBuilder("authority").setTitle("Authority - O").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField()) // authority
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -271,7 +272,7 @@ public final class NdkChapterForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - M").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah kapitoly."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
@@ -272,7 +272,7 @@ public final class NdkChapterForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - M").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah kapitoly."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographSupplementForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographSupplementForm.java
@@ -424,6 +424,7 @@ public final class NdkMonographSupplementForm {
                 .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField()) // authority
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -435,7 +436,7 @@ public final class NdkMonographSupplementForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - MA").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah přílohy."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographVolumeForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkMonographVolumeForm.java
@@ -439,6 +439,7 @@ public final class NdkMonographVolumeForm {
                 .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField())
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -452,7 +453,7 @@ public final class NdkMonographVolumeForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - R").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah monografie."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalForm.java
@@ -398,6 +398,7 @@ public final class NdkPeriodicalForm {
                 .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField())
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -411,7 +412,7 @@ public final class NdkPeriodicalForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - R").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah periodika."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalIssueForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalIssueForm.java
@@ -475,9 +475,10 @@ public final class NdkPeriodicalIssueForm {
                 .setHint("Údaje o věcném třídění.<p>Použití u ročenek, specializovaných periodik,"
                     + " tematických čísel nebo zvláštních vydání.")
                 // @ID, @authorityAttributeGroup, @languageAttributeGroup, @xlink:simpleLink, @displayLabel, @altRepGroup, @usage
-                .addField(new FieldBuilder("authority").setTitle("Authority - RA").setMaxOccurrences(1).setType(Field.TEXT)
+                .addField(new FieldBuilder("authority").setTitle("Authority - RA").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField()) // authority
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -489,7 +490,7 @@ public final class NdkPeriodicalIssueForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - R").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah čísla periodika."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalSupplementForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPeriodicalSupplementForm.java
@@ -433,6 +433,7 @@ public final class NdkPeriodicalSupplementForm {
                 .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField()) // authority
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -444,7 +445,7 @@ public final class NdkPeriodicalSupplementForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - MA").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah přílohy."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPictureForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkPictureForm.java
@@ -231,6 +231,7 @@ public final class NdkPictureForm {
                 .addField(new FieldBuilder("authority").setTitle("Authority - O").setMaxOccurrences(1).setType(Field.TEXT)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField()) // authority
 
 
@@ -243,7 +244,7 @@ public final class NdkPictureForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - M").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah článku."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkSheetMusicForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkSheetMusicForm.java
@@ -389,6 +389,7 @@ public final class NdkSheetMusicForm {
                 .addField(new FieldBuilder("authority").setTitle("Authority - R").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField())
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -402,7 +403,7 @@ public final class NdkSheetMusicForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - R").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah dokumentu."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/bdm/BornDigitalArticleForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/bdm/BornDigitalArticleForm.java
@@ -407,7 +407,7 @@ public final class BornDigitalArticleForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - M").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah článku."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
+                            + " nebo obsah pole 650 záznamu MARC21 nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/bdm/BornDigitalArticleForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/bdm/BornDigitalArticleForm.java
@@ -384,9 +384,10 @@ public final class BornDigitalArticleForm {
         return new FieldBuilder("subject").setTitle("Subject - R").setMaxOccurrences(30)
                 .setHint("Údaje o věcném třídění.")
                 // @ID, @authorityAttributeGroup, @languageAttributeGroup, @xlink:simpleLink, @displayLabel, @altRepGroup, @usage
-                .addField(new FieldBuilder("authority").setTitle("Authority - O").setMaxOccurrences(1).setType(Field.TEXT)
+                .addField(new FieldBuilder("authority").setTitle("Authority - O").setMaxOccurrences(1).setType(Field.COMBO)
                     .addMapValue("czenas", "czenas")
                     .addMapValue("eczenas", "eczenas")
+                    .addMapValue("Konspekt", "Konspekt")
                 .createField()) // authority
 
                 // topic, stringPlusLanguagePlusAuthority
@@ -406,7 +407,7 @@ public final class BornDigitalArticleForm {
                     .addField(new FieldBuilder("value").setTitle("Topic - M").setMaxOccurrences(1).setType(Field.TEXT)
                         .setHint("Libovolný výraz specifikující nebo charakterizující obsah článku."
                             + "<p>Použít kontrolovaný slovník - např. z báze autorit AUT NK ČR (věcné téma)"
-                            + " nebo obsah pole 650 záznamu MARC21.")
+                            + " nebo obsah pole 650 záznamu MARC21  nebo obsah pole 072 $x.")
                     .createField()) // value
                 .createField()) // topic
 


### PR DESCRIPTION
Podle #594 upraven formulář metadat tak, aby bylo možné zaznamenat do mods:subject klasifikační údaje věcného třídění podle Konspektu.

Současná verze šablony již umí stáhnout tyto pole a údaje se přenesou přímo do formuláře (Vyplní se, jak hodnota Authority, tak i hodnota topic). Zkoušeno na monografii stažené z Alephu ISBN = 978-80-7390-006-9.

Ve specifikaci bod https://docs.google.com/document/d/1cWvwfk9bVpTGfeSwQOKfDQlbIyEkJEL-LcMU6bmQL1A/edit#heading=h.4d34og8