### PR TITLE
issue #557: fix article radiobutton

### DIFF
--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/presenter/ModsCustomEditor.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/presenter/ModsCustomEditor.java
@@ -210,6 +210,8 @@ public final class ModsCustomEditor extends AbstractDatastreamEditor implements 
                     metadata = dm;
                     Record customModsRecord = dm.getDescription();
                     if (customModsRecord != null) {
+                        // fix https://github.com/proarc/proarc/issues/557
+                        activeEditor.clear();
                         // refresh editor with server values
                         activeEditor.editRecord(customModsRecord);
                     }
@@ -383,6 +385,8 @@ public final class ModsCustomEditor extends AbstractDatastreamEditor implements 
                 Record customModsRecord = dm.getDescription();
                 if (customModsRecord != null) {
                     metadata = dm;
+                    // fix https://github.com/proarc/proarc/issues/557
+                    editor.clear();
                     editor.editRecord(customModsRecord);
                     editor.clearErrors(true);
                     loadCallback.execute(Boolean.TRUE);


### PR DESCRIPTION
> Chybu jsme zaznamenali až po nasazení verze 3.3.
Zkoušel jsem Proarc ve verzi 3.2, ale chyba se mi projevila už v něm.


 Vypadá to na nějaký bug ve SmartGWT, která se nastane pouze při použití Radio (Select i Combo funguje v pořádku). Zkoušel jsem SmartGWT aktualizovat na aktuální build 6.0p, ale nepomohlo to.

Přikládám změnu obsahující drobný workaround, který problém řeší. Pomůže zavolat clear nad celým widgetem formuláře (https://www.smartclient.com/smartgwt/javadoc/com/smartgwt/client/widgets/Canvas.html#clear--), clearValues je nedostačující.

RadioButton teď funguje, testoval jsem to ve Firefoxu i v Chrome.

Btw. nejspíš z důvodu blbnoucího radia Lukáš použil pro volbu AACR/RDA combo. Radio by bylo v tomto případě vhodnější. Combo je ostatně špatně, uživatel může zadat jakoukoliv hodnotu (viz https://github.com/proarc/proarc/issues/605), hodnota potom nejde ani uložit.