### PR TITLE
issue #427: Set attribute directly to dsRequest

### DIFF
--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/ds/StreamProfileDataSource.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/ds/StreamProfileDataSource.java
@@ -158,7 +158,7 @@ public class StreamProfileDataSource extends ProarcDataSource {
             template("NDK_USER", i18n.DigitalObjectEditor_MediaEditor_DSNdkUser_Title());
 
             reorderTemplates(source);
-            return TEMPLATES;
+            return Collections.unmodifiableList(TEMPLATES);
         }
 
         /**

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/MediaEditor.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/MediaEditor.java
@@ -364,7 +364,11 @@ public final class MediaEditor implements DatastreamEditor, Refreshable {
         Criteria streamMenuFilter = dobj.toCriteria();
         streamMenu.setPickListCriteria(streamMenuFilter);
         streamMenu.setAttribute(SOURCE_IDENTIFIER, getLastSelectionId(dobj, source));
-        streamMenu.fetchData();
+
+        DSRequest dsRequest = new DSRequest();
+        dsRequest.setAttribute(SOURCE_IDENTIFIER, getLastSelectionId(dobj, source));
+
+        streamMenu.fetchData((dsResponse, o, dsRequest1) -> {}, dsRequest);
     }
 
     private void updateStreamMenu(ResultSet data, SelectItem view) {

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/MediaEditor.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/MediaEditor.java
@@ -363,7 +363,6 @@ public final class MediaEditor implements DatastreamEditor, Refreshable {
     private void updateStreamMenu(DigitalObject dobj) {
         Criteria streamMenuFilter = dobj.toCriteria();
         streamMenu.setPickListCriteria(streamMenuFilter);
-        streamMenu.setAttribute(SOURCE_IDENTIFIER, getLastSelectionId(dobj, source));
 
         DSRequest dsRequest = new DSRequest();
         dsRequest.setAttribute(SOURCE_IDENTIFIER, getLastSelectionId(dobj, source));


### PR DESCRIPTION
changed:
+ attribute with request source is now set directly to dsrequest for BDM
uploading
+ template list is returned as unmodifiable list (preventing unexpected
behaviour in future updates)