### PR TITLE
issue #628: repair metadata version

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/MetsUtils.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/MetsUtils.java
@@ -887,9 +887,9 @@ public class MetsUtils {
             infoJaxb.setCreator(metsContext.getOptions().getCreator());
             infoJaxb.setPackageid(metsContext.getPackageID());
             if (Const.PERIODICAL_TITLE.equalsIgnoreCase(metsContext.getRootElement().getElementType())) {
-                infoJaxb.setMetadataversion((float) 1.5);
+                infoJaxb.setMetadataversion((float) 1.6);
             } else {
-                infoJaxb.setMetadataversion((float) 1.1);
+                infoJaxb.setMetadataversion((float) 1.2);
             }
             Itemlist itemList = new Itemlist();
             infoJaxb.setItemlist(itemList);


### PR DESCRIPTION
Podle issue opraveno číslo standardu:
- Periodika z 1.5 na 1.6
- Monografie z 1.1 na 1.2