### PR TITLE
issue #658: workaround for empty OCR (replace it with newline)

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/Kramerius4Export.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/Kramerius4Export.java
@@ -35,6 +35,7 @@ import cz.cas.lib.proarc.common.fedora.RemoteStorage;
 import cz.cas.lib.proarc.common.fedora.RemoteStorage.RemoteObject;
 import cz.cas.lib.proarc.common.fedora.SearchView;
 import cz.cas.lib.proarc.common.fedora.SearchView.Item;
+import cz.cas.lib.proarc.common.fedora.StringEditor;
 import cz.cas.lib.proarc.common.fedora.relation.RelationEditor;
 import cz.cas.lib.proarc.common.fedora.relation.RelationResource;
 import cz.cas.lib.proarc.common.fedora.relation.Relations;
@@ -275,6 +276,7 @@ public final class Kramerius4Export {
             renameDatastream(datastream);
             processDublinCore(datastream);
             processMods(datastream);
+            processOcr(datastream);
             processRelsExt(dobj.getPID(), datastream, editor, null);
         }
     }
@@ -356,6 +358,22 @@ public final class Kramerius4Export {
         Element mods = xmlContent.getAny().get(0);
         removeNils(mods);
         wrapModsInCollection(xmlContent);
+    }
+
+    /**
+     * Replace empty OCR with lineseparator
+     * Fedora 3.8 can't ingest empty stream (https://github.com/proarc/proarc/issues/658)
+     *
+     * @param datastream
+     */
+    private void processOcr(DatastreamType datastream) {
+        if (!StringEditor.OCR_ID.equals(datastream.getID())) {
+            return ;
+        }
+        DatastreamVersionType version = datastream.getDatastreamVersion().get(0);
+        if (version.getBinaryContent().length == 0) {
+            version.setBinaryContent(System.lineSeparator().getBytes());
+        }
     }
 
     /**

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/export/Kramerius4ExportTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/export/Kramerius4ExportTest.java
@@ -32,20 +32,41 @@ import cz.cas.lib.proarc.common.object.DigitalObjectManager;
 import cz.cas.lib.proarc.common.object.model.MetaModelRepository;
 import cz.cas.lib.proarc.common.user.UserManager;
 import cz.cas.lib.proarc.oaidublincore.DcConstants;
-import java.io.File;
-import java.util.HashMap;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.AfterClass;
-import static org.junit.Assert.*;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.io.StringWriter;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * 
@@ -55,6 +76,8 @@ public class Kramerius4ExportTest {
 
     @Rule
     public CustomTemporaryFolder temp = new CustomTemporaryFolder(true);
+
+    private static FedoraTestSupport fedora;
 
     @BeforeClass
     public static void setUpClass() {
@@ -70,21 +93,8 @@ public class Kramerius4ExportTest {
         config = AppConfigurationFactory.getInstance().create(new HashMap<String, String>() {{
             put(AppConfiguration.PROPERTY_APP_HOME, temp.getRoot().getPath());
         }});
-    }
-
-    @After
-    public void tearDown() {
-    }
-
-    /**
-     * integration test
-     */
-    @Test
-    public void testExport() throws Exception {
-        FedoraTestSupport fedora = new FedoraTestSupport();
+        fedora = new FedoraTestSupport();
         fedora.cleanUp();
-        fedora.ingest(Kramerius4ExportTest.class.getResource("Kramerius4ExportTestPage.xml"));
-
         MetaModelRepository.setInstance(config.getPlugins());
         DigitalObjectManager.setDefault(new DigitalObjectManager(
                 config,
@@ -93,6 +103,81 @@ public class Kramerius4ExportTest {
                 MetaModelRepository.getInstance(),
                 EasyMock.createNiceMock(UserManager.class)));
 
+        // check datastreams with xpath
+        HashMap<String, String> namespaces = new HashMap<>();
+        namespaces.put("dc", DcConstants.NS_PURL);
+        namespaces.put("f", "info:fedora/fedora-system:def/foxml#");
+        namespaces.put("kramerius", Kramerius4Export.KRAMERIUS_RELATION_NS);
+        namespaces.put("mods", ModsStreamEditor.DATASTREAM_FORMAT_URI);
+        namespaces.put("oai", Kramerius4Export.OAI_NS);
+        namespaces.put("proarc-rels", Relations.PROARC_RELS_NS);
+        XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(namespaces));
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testEmptyOcrExport() throws Exception {
+        URL url = Kramerius4ExportTest.class.getResource("Kramerius4ExportTestPage.xml");
+        Path resPath = Paths.get(url.toURI());
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document doc = db.parse(resPath.toFile());
+
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        NodeList nl = (NodeList)xpath
+                .compile("//datastream[@ID='TEXT_OCR']/datastreamVersion/binaryContent")
+                .evaluate(doc, XPathConstants.NODESET);
+
+        Path emptyOcr = Files.createTempFile("proarcKramerius4ExportTest", null);
+        emptyOcr.toFile().setReadable(true, false);
+        emptyOcr.toFile().deleteOnExit();
+        for (int i = 0; i < nl.getLength(); i++) {
+            Node binaryContentNode = nl.item(i);
+            Element contentLocation = doc.createElement("contentLocation");
+            contentLocation.setAttribute("TYPE", "URL");
+            contentLocation.setAttribute("REF", emptyOcr.toUri().toString());
+            nl.item(i).getParentNode().replaceChild(contentLocation, binaryContentNode);
+        }
+        DOMSource domSource = new DOMSource(doc);
+        StringWriter writer = new StringWriter();
+        StreamResult result = new StreamResult(writer);
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.transform(domSource, result);
+        writer.flush();
+        String xml = writer.toString();
+        fedora.ingest(xml);
+
+        File output = temp.getRoot();
+        boolean hierarchy = true;
+        String[] pids = {"uuid:f74f3cf3-f3be-4cac-95da-8e50331414a2"};
+        RemoteStorage storage = fedora.getRemoteStorage();
+        Kramerius4Export instance = new Kramerius4Export(storage, config.getKramerius4Export());
+        File target = instance.export(output, hierarchy, "export status", pids);
+        assertNotNull(target);
+        File foxml = ExportUtils.pidAsXmlFile(target, pids[0]);
+        String foxmlAsURI = foxml.toURI().toASCIIString();
+
+        XMLAssert.assertXpathEvaluatesTo(DatatypeConverter.printBase64Binary(System.lineSeparator().getBytes()),
+                streamXPath(StringEditor.OCR_ID) + "//f:binaryContent", new InputSource(foxmlAsURI));
+
+        // test ingest of exported object
+        fedora.cleanUp();
+        fedora.ingest(foxml.toURI().toURL());
+    }
+
+    /**
+     * integration test
+     */
+    @Test
+    public void testExport() throws Exception {
+        fedora.ingest(Kramerius4ExportTest.class.getResource("Kramerius4ExportTestPage.xml"));
         File output = temp.getRoot();
         boolean hierarchy = true;
         String[] pids = {"uuid:f74f3cf3-f3be-4cac-95da-8e50331414a2"};
@@ -102,14 +187,6 @@ public class Kramerius4ExportTest {
         assertNotNull(target);
 
         // check datastreams with xpath
-        HashMap<String, String> namespaces = new HashMap<String, String>();
-        namespaces.put("dc", DcConstants.NS_PURL);
-        namespaces.put("f", "info:fedora/fedora-system:def/foxml#");
-        namespaces.put("kramerius", Kramerius4Export.KRAMERIUS_RELATION_NS);
-        namespaces.put("mods", ModsStreamEditor.DATASTREAM_FORMAT_URI);
-        namespaces.put("oai", Kramerius4Export.OAI_NS);
-        namespaces.put("proarc-rels", Relations.PROARC_RELS_NS);
-        XMLUnit.setXpathNamespaceContext(new SimpleNamespaceContext(namespaces));
         File foxml = ExportUtils.pidAsXmlFile(target, pids[0]);
         String foxmlSystemId = foxml.toURI().toASCIIString();
         XMLAssert.assertXpathExists(streamXPath(ModsStreamEditor.DATASTREAM_ID), new InputSource(foxmlSystemId));

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/fedora/FedoraTestSupport.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/fedora/FedoraTestSupport.java
@@ -22,6 +22,7 @@ import com.yourmediashelf.fedora.client.response.FindObjectsResponse;
 import com.yourmediashelf.fedora.generated.foxml.DigitalObject;
 import cz.cas.lib.proarc.common.fedora.LocalStorage.LocalObject;
 import cz.cas.lib.proarc.common.fedora.SearchView.Item;
+import java.io.StringReader;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -77,6 +78,12 @@ public class FedoraTestSupport {
         }
     }
 
+    public void ingest(String... xml) throws Exception {
+        for (String x : xml) {
+            ingestFromXML(x);
+        }
+    }
+
     public String getTestUser() {
         return "junit";
     }
@@ -84,6 +91,13 @@ public class FedoraTestSupport {
     private void ingestFromUrl(URL foxml) throws Exception {
         assertNotNull(foxml);
         DigitalObject dobj = FoxmlUtils.unmarshal(new StreamSource(foxml.toExternalForm()), DigitalObject.class);
+        LocalObject object = new LocalStorage().create(dobj);
+        storage.ingest(object, "junit");
+    }
+
+    private void ingestFromXML(String xml) throws Exception {
+        assertNotNull(xml);
+        DigitalObject dobj = FoxmlUtils.unmarshal(new StreamSource(new StringReader(xml)), DigitalObject.class);
         LocalObject object = new LocalStorage().create(dobj);
         storage.ingest(object, "junit");
     }


### PR DESCRIPTION
Prázdné OCR je nahrazeno prázdným řádkem, takový interní datastream už Fedora akceptuje.