### PR TITLE
issue #518: mastercopy part of MIX shout not contain ImageCaptureMeta…

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/JhoveUtility.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/JhoveUtility.java
@@ -102,7 +102,7 @@ public class JhoveUtility {
      *
      * Inits the Jhove app
      *
-     * @param metsInfo
+     * @param metsContext
      */
     public static void initJhove(MetsContext metsContext) throws MetsExportException {
         if (metsContext.getJhoveContext() == null) {
@@ -253,12 +253,12 @@ public class JhoveUtility {
     }
 
     /**
-     * Inserts dateCreated into Mix
+     * Inserts ImageCaptureMetadata into Mix
      *
      * @param mix
      * @param dateCreated
      */
-    public static void insertDateCreated(Mix mix, XMLGregorianCalendar dateCreated) {
+    public static void insertImageCaptureMetadata(Mix mix, XMLGregorianCalendar dateCreated) {
         // inserts DateCreated if missing
         if ((mix.getImageCaptureMetadata() == null) ||
                 (mix.getImageCaptureMetadata().getGeneralCaptureInformation() == null) ||
@@ -373,7 +373,7 @@ public class JhoveUtility {
             mergeMix(mix, deviceMix);
             // insert date time created
             if ((dateCreated != null) && (mix != null)) {
-                insertDateCreated(mix, dateCreated);
+                insertImageCaptureMetadata(mix, dateCreated);
             }
 
             // insert ChangeHistory

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/structure/MetsElementVisitor.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/export/mets/structure/MetsElementVisitor.java
@@ -920,7 +920,7 @@ public class MetsElementVisitor implements IMetsElementVisitor {
         JhoveUtility.insertObjectIdentifier(jHoveOutputRaw.getMix(), originalPid, "RAW");
         JhoveUtility.addDenominator(jHoveOutputRaw);
         JhoveUtility.addOrientation(jHoveOutputRaw);
-        JhoveUtility.insertDateCreated(jHoveOutputRaw.getMix(), rawCreated);
+        JhoveUtility.insertImageCaptureMetadata(jHoveOutputRaw.getMix(), rawCreated);
     }
 
     /**
@@ -938,7 +938,6 @@ public class MetsElementVisitor implements IMetsElementVisitor {
         JhoveUtility.addPhotometricInformation(jHoveOutputMC, photometricInterpretation);
         JhoveUtility.addDenominator(jHoveOutputMC);
         JhoveUtility.addOrientation(jHoveOutputMC);
-        JhoveUtility.insertDateCreated(jHoveOutputMC.getMix(), mcCreated);
     }
 
     /**


### PR DESCRIPTION
ImageCaptureMetadata se nyní do MIXu zařadí pouze pro původní sken. Pro mastercopy se element nepoužije.