### PR TITLE
moravianlibrary#2: enable processing import batches of 'proarc' user

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/dao/empiredb/EmpireBatchDao.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/dao/empiredb/EmpireBatchDao.java
@@ -167,7 +167,8 @@ public class EmpireBatchDao extends EmpireDao implements BatchDao {
         cmd.select(ut.username);
         cmd.join(table.userId, ut.id);
         if (filter.getUserId() != null) {
-            cmd.where(ut.id.is(filter.getUserId()));
+            cmd.where(ut.id.in(new Integer[]{1, filter.getUserId()}));
+            //cmd.where(ut.id.is(filter.getUserId()));
         }
         if (filter.getBatchId() != null) {
             cmd.where(table.id.is(filter.getBatchId()));

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/imports/ImportProcess.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/imports/ImportProcess.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
 public final class ImportProcess implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(ImportProcess.class.getName());
-    static final String TMP_DIR_NAME = "proarc_import";
+    public static final String TMP_DIR_NAME = "proarc_import";
     private final ImportBatchManager batchManager;
     private static List<ImageImporter> consumerRegistery;
     private final ImportOptions importConfig;

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/dao/empiredb/EmpireBatchDaoTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/dao/empiredb/EmpireBatchDaoTest.java
@@ -272,7 +272,7 @@ public class EmpireBatchDaoTest {
         view = dao.view(1, null, State.LOADING_FAILED, 0);
         assertEquals(0, view.size());
         view = dao.view(2, null, null, 0);
-        assertEquals(0, view.size());
+        assertEquals(1, view.size());
     }
 
     @Test
@@ -292,7 +292,7 @@ public class EmpireBatchDaoTest {
         view = dao.view(1, null, State.LOADING, 0);
         assertEquals(1, view.size());
         view = dao.view(20, null, null, 0);
-        assertEquals(0, view.size());
+        assertEquals(2, view.size());
 
         // test paging
         view = dao.view(1, null, null, null, null, 0, 1, null);

--- a/proarc-common/src/test/resources/cz/cas/lib/proarc/common/dao/empiredb/batch.xml
+++ b/proarc-common/src/test/resources/cz/cas/lib/proarc/common/dao/empiredb/batch.xml
@@ -7,5 +7,11 @@
         CREATE="2013-01-17 12:12:12.000" timestamp="{$now}" profile_id="profile.default"
     />
 
+    <proarc_batch id="2" folder="folder2/" title="title_folder2/" user_id="800"
+                  state="LOADING" parent_pid="uuid:0eaa6730-9068-11dd-97de-111d606f5dc6"
+                  estimate_number="2" device="device:scanner" generate_indices="1" log="log"
+                  CREATE="2013-01-17 12:12:12.000" timestamp="{$now}" profile_id="profile.default"
+    />
+
     <proarc_batch_item />
 </dataset>

--- a/proarc-common/src/test/resources/cz/cas/lib/proarc/common/dao/empiredb/batch_with_items.xml
+++ b/proarc-common/src/test/resources/cz/cas/lib/proarc/common/dao/empiredb/batch_with_items.xml
@@ -11,6 +11,11 @@
         estimate_number="3" device="device:scanner2" generate_indices="1" log="log2"
         CREATE="2013-01-18 12:12:12.000" timestamp="{$now}"
     />
+    <proarc_batch id="3" folder="folder3/" title="title_folder3/" user_id="800"
+                  state="LOADED" parent_pid="pid:3"
+                  estimate_number="3" device="device:scanner2" generate_indices="1" log="log2"
+                  CREATE="2013-01-18 12:13:12.000" timestamp="{$now}"
+    />
 
     <proarc_batch_item id="1" batch_id="1" pid="pid:item:1" timestamp="{$now}"
                        file="file1.xml" state="LOADED" type="OBJECT" log="log"
@@ -44,6 +49,9 @@
                        file="file5.tiff" state="OK" type="FILE"
     />
     <proarc_batch_item id="11" batch_id="2" timestamp="{$now}"
+                       file="file6.unknown" state="SKIPPED" type="FILE"
+    />
+    <proarc_batch_item id="12" batch_id="3" timestamp="{$now}"
                        file="file6.unknown" state="SKIPPED" type="FILE"
     />
 </dataset>


### PR DESCRIPTION
Other users now can edit import batches of user 'proarc' (id 1). Upon ingesting batch into remote storage, username is updated to current user.