### PR TITLE
issue #689: MARC21 to MODS3 edit: split author name into nameParts

### DIFF
--- a/proarc-common/src/main/resources/xml/MARC21slim2MODS3.xsl
+++ b/proarc-common/src/main/resources/xml/MARC21slim2MODS3.xsl
@@ -8,6 +8,7 @@
     <!-- Maintenance note: For each revision, change the content of <recordInfo><recordOrigin> to reflect the new revision number.
     MARC21slim2MODS3-5 (Revision 1.97) 20140521 / (ProArc patch 11.433) 20160318
 
+Revision 1.98.proarc.13.689 - Changed handling 100,700: value is split into given and family <namePart> if it contains ',' 2018/02/09
 Revision 1.97.proarc.12.298 - Added mapping for 264 ind 4 to originInfo 2017/09/01
 Revision 1.97.proarc.11.433 - ProArc patch of mapping 653$09 and 653$0_ to subject/topic@lang 2016/03/18
 Revision 1.97.proarc.10.434 - ProArc patch of mapping 520$9 to abstract@lang 2016/03/02
@@ -2739,7 +2740,7 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
             </xsl:for-each>
 
             <recordOrigin>Converted from MARCXML to MODS version 3.5 using MARC21slim2MODS3.xsl
-                (Revision 1.97 2014/05/21, ProArc patch 12.298 2017/09/01)</recordOrigin>
+                (Revision 1.98 2018/02/09, ProArc patch 13.689 2018/02/09)</recordOrigin>
 
             <xsl:for-each select="marc:datafield[@tag=040]/marc:subfield[@code='b']">
                 <languageOfCataloging>
@@ -3009,18 +3010,54 @@ Revision 1.02 - Added Log Comment  2003/03/24 19:37:42  ckeith
         </xsl:if>
     </xsl:template>
     <xsl:template name="nameABCDQ">
-        <namePart>
-            <xsl:call-template name="chopPunctuation">
-                <xsl:with-param name="chopString">
-                    <xsl:call-template name="subfieldSelect">
-                        <xsl:with-param name="codes">aq</xsl:with-param>
-                    </xsl:call-template>
-                </xsl:with-param>
-                <xsl:with-param name="punctuation">
-                    <xsl:text>:,;/ </xsl:text>
-                </xsl:with-param>
+        <!--Revision 1.98.proarc.13.689-->
+        <xsl:param name="nameString">
+            <xsl:call-template name="subfieldSelect">
+                <xsl:with-param name="codes">aq</xsl:with-param>
             </xsl:call-template>
-        </namePart>
+        </xsl:param>
+        <xsl:choose>
+            <xsl:when test="contains($nameString, ',')">
+                <namePart type="family">
+                    <xsl:call-template name="stringPunctuationFront">
+                        <xsl:with-param name="chopString">
+                            <xsl:call-template name="subfieldSelect">
+                                <xsl:with-param name="codes">aq</xsl:with-param>
+                            </xsl:call-template>
+                        </xsl:with-param>
+                        <xsl:with-param name="punctuation">
+                            <xsl:text>,</xsl:text>
+                        </xsl:with-param>
+                    </xsl:call-template>
+                </namePart>
+                <namePart type="given">
+                    <xsl:call-template name="stringPunctuationBack">
+                        <xsl:with-param name="chopString">
+                            <xsl:call-template name="subfieldSelect">
+                                <xsl:with-param name="codes">aq</xsl:with-param>
+                            </xsl:call-template>
+                        </xsl:with-param>
+                        <xsl:with-param name="punctuation">
+                            <xsl:text>,</xsl:text>
+                        </xsl:with-param>
+                    </xsl:call-template>
+                </namePart>
+            </xsl:when>
+            <xsl:otherwise>
+                <namePart>
+                    <xsl:call-template name="chopPunctuation">
+                        <xsl:with-param name="chopString">
+                            <xsl:call-template name="subfieldSelect">
+                                <xsl:with-param name="codes">aq</xsl:with-param>
+                            </xsl:call-template>
+                        </xsl:with-param>
+                        <xsl:with-param name="punctuation">
+                            <xsl:text>,</xsl:text>
+                        </xsl:with-param>
+                    </xsl:call-template>
+                </namePart>
+            </xsl:otherwise>
+        </xsl:choose>
         <xsl:call-template name="termsOfAddress"/>
         <xsl:call-template name="nameDate"/>
     </xsl:template>

--- a/proarc-common/src/main/resources/xml/MARC21slimUtils.xsl
+++ b/proarc-common/src/main/resources/xml/MARC21slimUtils.xsl
@@ -5,6 +5,7 @@
     <!-- 08/08/08: tmee added corrected chopPunctuation templates for 260c -->
     <!-- 08/19/04: ntra added "marc:" prefix to datafield element -->
     <!-- 12/14/07: ntra added url encoding template -->
+    <!-- 18/09/02: added template for separating family and given namePart for 689-->
     <!-- url encoding -->
 
     <xsl:variable name="ascii">
@@ -96,6 +97,47 @@
         </xsl:choose>
     </xsl:template>
 
+    <xsl:template name="stringPunctuationFront">
+        <xsl:param name="chopString"/>
+        <xsl:param name="punctuation">
+            <xsl:text>,</xsl:text>
+        </xsl:param>
+        <xsl:variable name="length" select="string-length($chopString)"/>
+        <xsl:choose>
+            <xsl:when test="$length=0"/>
+            <xsl:when test="contains($chopString, $punctuation)">
+                <xsl:call-template name="chopPunctuation">
+                    <xsl:with-param name="chopString" select="substring-before($chopString,$punctuation)"/>
+                    <xsl:with-param name="punctuation" select="$punctuation"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="not($chopString)"/>
+            <xsl:otherwise>
+                <xsl:value-of select="$chopString"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="stringPunctuationBack">
+        <xsl:param name="chopString"/>
+        <xsl:param name="punctuation">
+            <xsl:text>,</xsl:text>
+        </xsl:param>
+        <xsl:variable name="length" select="string-length($chopString)"/>
+        <xsl:choose>
+            <xsl:when test="$length=0"/>
+            <xsl:when test="contains($chopString, $punctuation)">
+                <xsl:call-template name="chopPunctuationFrontAndBack">
+                    <xsl:with-param name="chopString" select="substring-after($chopString,$punctuation)"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="not($chopString)"/>
+            <xsl:otherwise>
+                <xsl:value-of select="$chopString"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
     <xsl:template name="chopPunctuationFront">
         <xsl:param name="chopString"/>
         <xsl:variable name="length" select="string-length($chopString)"/>
@@ -124,6 +166,33 @@
             <xsl:when test="$length=0"/>
             <xsl:when test="contains($punctuation, substring($chopString,$length,1))">
                 <xsl:call-template name="chopPunctuation">
+                    <xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
+                    <xsl:with-param name="punctuation" select="$punctuation"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="not($chopString)"/>
+            <xsl:otherwise>
+                <xsl:value-of select="$chopString"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="chopPunctuationFrontAndBack">
+        <xsl:param name="chopString"/>
+        <xsl:param name="punctuation">
+            <xsl:text>.:,;/] </xsl:text>
+        </xsl:param>
+        <xsl:variable name="length" select="string-length($chopString)"/>
+        <xsl:choose>
+            <xsl:when test="$length=0"/>
+            <xsl:when test="contains('.:,;/[ ', substring($chopString,1,1))">
+                <xsl:call-template name="chopPunctuationFrontAndBack">
+                    <xsl:with-param name="chopString" select="substring($chopString,2,$length - 1)"
+                    />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:when test="contains($punctuation, substring($chopString,$length,1))">
+                <xsl:call-template name="chopPunctuationFrontAndBack">
                     <xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
                     <xsl:with-param name="punctuation" select="$punctuation"/>
                 </xsl:call-template>

--- a/proarc-common/src/test/java/cz/cas/lib/proarc/common/xml/TransformersTest.java
+++ b/proarc-common/src/test/java/cz/cas/lib/proarc/common/xml/TransformersTest.java
@@ -43,11 +43,14 @@ import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.After;
 import org.junit.AfterClass;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.InputSource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -293,14 +296,16 @@ public class TransformersTest {
             XMLAssert.assertXpathExists("/m:mods/m:name[@type='personal'"
                         + " and @authorityURI='http://aut.nkp.cz'"
                         + " and @valueURI='http://aut.nkp.cz/xx0113245']"
-                    + "/m:namePart[text()='Kocina, Jan']"
+                    + "/m:namePart[@type='family' and text()='Kocina']"
+                    + "/../m:namePart[@type='given' and text()='Jan']"
                     + "/../m:namePart[@type='date' and text()='1960-']"
                     + "/../m:role/m:roleTerm[text()='aut']", xmlResult);
             // test 700 1# $a Honzík, Bohumil, $d 1972- $4 aut $7 jn20020422016
             XMLAssert.assertXpathExists("/m:mods/m:name[@type='personal'"
                         + " and @authorityURI='http://aut.nkp.cz'"
                         + " and @valueURI='http://aut.nkp.cz/jn20020422016']"
-                    + "/m:namePart[text()='Honzík, Bohumil']"
+                    + "/m:namePart[@type='family' and text()='Honzík']"
+                    + "/../m:namePart[@type='given' and text()='Bohumil']"
                     + "/../m:namePart[@type='date' and text()='1972-']"
                     + "/../m:role/m:roleTerm[text()='aut']", xmlResult);
             // test 700 1# $a Test Without AuthorityId $d 1972- $4 aut


### PR DESCRIPTION
- Author name is now divided into `family` and `given` part if 100/700
fields contain ','