### PR TITLE
issue #694: set default value in DescriptionStandard

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/RdaRules.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/RdaRules.java
@@ -61,7 +61,7 @@ public class RdaRules {
 
     public void check() throws DigitalObjectValidationException{
         if (HAS_MEMBER_RDA_VALIDATION_MODELS.contains(modelId)) {
-            checkRules(mods);
+            checkAndRepairRules(mods);
             for (OriginInfoDefinition oi : mods.getOriginInfo()) {
                 checkOriginInfoRdaRules(oi);
             }
@@ -116,7 +116,7 @@ public class RdaRules {
     }
 
     /** Checks if the correct fields are filled depending on eventType */
-    protected void checkRules(ModsDefinition mods) {
+    protected void checkAndRepairRules(ModsDefinition mods) {
         if (mods.getRecordInfo().isEmpty()) {
             return;
         }

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/RdaRules.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/RdaRules.java
@@ -18,11 +18,9 @@ package cz.cas.lib.proarc.common.object.ndk;
 
 import cz.cas.lib.proarc.common.fedora.DigitalObjectValidationException;
 import cz.cas.lib.proarc.common.mods.custom.ModsConstants;
-import cz.cas.lib.proarc.mods.DateDefinition;
-import cz.cas.lib.proarc.mods.ModsDefinition;
-import cz.cas.lib.proarc.mods.OriginInfoDefinition;
-import cz.cas.lib.proarc.mods.PhysicalDescriptionDefinition;
-import cz.cas.lib.proarc.mods.StringPlusLanguagePlusAuthority;
+import cz.cas.lib.proarc.mods.*;
+import org.apache.xpath.SourceTree;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -121,7 +119,11 @@ public class RdaRules {
         List<StringPlusLanguagePlusAuthority> descriptionStandards = mods.getRecordInfo().get(0).getDescriptionStandard();
         String descriptionStandard = descriptionStandards.isEmpty() ? null : descriptionStandards.get(0).getValue();
         if (descriptionStandard == null) {
-            exception.addValidation("RDA rules", ERR_NDK_DESCRIPTIONSTANDARD);
+            StringPlusLanguagePlusAuthority description = new StringPlusLanguagePlusAuthority();
+            description.setValue(ModsConstants.VALUE_DESCRIPTIONSTANDARD_AACR);
+            RecordInfoDefinition recordInfoDefinition = new RecordInfoDefinition();
+            recordInfoDefinition.getDescriptionStandard().add(description);
+            mods.getRecordInfo().add(recordInfoDefinition);
         } else if (!ModsConstants.VALUE_DESCRIPTIONSTANDARD_RDA.equalsIgnoreCase(descriptionStandard)
                 && !ModsConstants.VALUE_DESCRIPTIONSTANDARD_AACR.equalsIgnoreCase(descriptionStandard)) {
             exception.addValidation("RDA rules", ERR_NDK_DESCRIPTIONSTANDARD);

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/RdaRules.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/object/ndk/RdaRules.java
@@ -18,8 +18,12 @@ package cz.cas.lib.proarc.common.object.ndk;
 
 import cz.cas.lib.proarc.common.fedora.DigitalObjectValidationException;
 import cz.cas.lib.proarc.common.mods.custom.ModsConstants;
-import cz.cas.lib.proarc.mods.*;
-import org.apache.xpath.SourceTree;
+import cz.cas.lib.proarc.mods.DateDefinition;
+import cz.cas.lib.proarc.mods.ModsDefinition;
+import cz.cas.lib.proarc.mods.OriginInfoDefinition;
+import cz.cas.lib.proarc.mods.PhysicalDescriptionDefinition;
+import cz.cas.lib.proarc.mods.RecordInfoDefinition;
+import cz.cas.lib.proarc.mods.StringPlusLanguagePlusAuthority;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Pokud se stáhne záznam z katalogu s nevyplněným polem pro RecordInfo:DescriptionStandard, je defualtně nastavena hodnota AACR