### PR TITLE
issue #759: RDflow menu nového záměru

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/workflow/model/TaskParameter.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/workflow/model/TaskParameter.java
@@ -110,7 +110,7 @@ public class TaskParameter {
     public void setValue(String value) throws WorkflowException {
         if (valueType == ValueType.NUMBER) {
             BigDecimal number = null;
-            if (value != null) {
+            if (value != null && !value.isEmpty()) {
                 if ("true".equals(value)) {
                     number = BigDecimal.ONE;
                 } else if ("false".equals(value)) {

--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/workflow/profile/SetParamDefinition.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/workflow/profile/SetParamDefinition.java
@@ -46,7 +46,7 @@ public class SetParamDefinition {
     }
 
     public String getValue() {
-        return value;
+        return value.trim();
     }
 
     public SetParamDefinition setValue(String value) {

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowNewJobView.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/workflow/WorkflowNewJobView.java
@@ -233,6 +233,8 @@ public class WorkflowNewJobView {
                         String profileId = r.getAttribute(WorkflowProfileDataSource.FIELD_ID);
                         profile.setValue(profileId);
                         profile.setDefaultValue(profileId);
+
+                        fetchModelMenu(r); // fill up model menu on init
                     }
                 }
             }


### PR DESCRIPTION
Možná po nějakém updatu smartgwt se přestal posílat changeddataevent při refreshi stránky - menu s modely se tedy vůbec neplnilo. Takže jsem doplnil plnění i na DataArrivedEvent.

+ přidal jsem trim na parametry z workflow.xml, abych předešel problému (který se v KNAV přesně stal), že uživatel nadefinguje param.export4K jako číslo, ale potom nastaví parametr takto:

```
<setParam paramRef="param.exportK4">
    </setParam>
```
do value se potom házel whitespace string (např \n\t) a validace čísla neprošla.