### PR TITLE
issue #806: enable unquoted control characters in JSON parser

### DIFF
--- a/proarc-common/src/main/java/cz/cas/lib/proarc/common/json/JsonUtils.java
+++ b/proarc-common/src/main/java/cz/cas/lib/proarc/common/json/JsonUtils.java
@@ -17,6 +17,7 @@
 package cz.cas.lib.proarc.common.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -54,6 +55,7 @@ public final class JsonUtils {
         om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         om.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
         om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        om.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
         return om;
     }
 


### PR DESCRIPTION
Mělo by řešit problém s načítáním publikací se speciálními znaky v metadatech.