### PR TITLE
issue #774: add element part:extent:unit in NdkArticle and NdkChapter

### DIFF
--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkArticleForm.java
@@ -460,6 +460,10 @@ public class NdkArticleForm {
                 // detail, type="detailDefinition"
                 // extent, type="extentDefinition"
                 .addField(new FieldBuilder("extent").setTitle("Extent - MA").setMaxOccurrences(10)
+                    .addField(new FieldBuilder("unit").setMaxOccurrences(1).setTitle("Unit - R").setType(Field.COMBO).setDefaultValue("pageIndex")
+                        .addMapValue("pageNumber", "Page Number")
+                        .addMapValue("pageIndex", "Page Index")
+                        .createField())
                     // start, type="stringPlusLanguage"
                     .addField(new FieldBuilder("start").setMaxOccurrences(1)
                         .addField(new FieldBuilder("value").setTitle("Start - MA").setMaxOccurrences(1).setType(Field.TEXT)

--- a/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
+++ b/proarc-webapp/src/main/java/cz/cas/lib/proarc/webapp/client/widget/mods/NdkChapterForm.java
@@ -423,6 +423,10 @@ public final class NdkChapterForm {
                 // detail, type="detailDefinition"
                 // extent, type="extentDefinition"
                 .addField(new FieldBuilder("extent").setTitle("Extent - MA").setMaxOccurrences(10)
+                    .addField(new FieldBuilder("unit").setMaxOccurrences(1).setTitle("Unit - R").setType(Field.COMBO).setDefaultValue("pageIndex")
+                        .addMapValue("pageNumber", "Page Number")
+                        .addMapValue("pageIndex", "Page Index")
+                        .createField())
                     // start, type="stringPlusLanguage"
                     .addField(new FieldBuilder("start").setMaxOccurrences(1)
                         .addField(new FieldBuilder("value").setTitle("Start - MA").setMaxOccurrences(1).setType(Field.TEXT)


### PR DESCRIPTION
Do formuláře NdkArticle a NdkChapter přidán nový elemnt <part:extent:unit>, který slouží k zapsani podřazených stránek. 

Více informací v issue #774. 