### PR TITLE
Oprava verzování v pom.xml souborech

### DIFF
--- a/proarc-common/pom.xml
+++ b/proarc-common/pom.xml
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>cz.cas.lib.proarc</groupId>
             <artifactId>proarc-aes57</artifactId>
-            <version>3.5-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/proarc-premis/pom.xml
+++ b/proarc-premis/pom.xml
@@ -9,17 +9,17 @@
         <dependency>
             <groupId>cz.cas.lib.proarc</groupId>
             <artifactId>proarc-mets</artifactId>
-            <version>3.5-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>cz.cas.lib.proarc</groupId>
             <artifactId>proarc-mets</artifactId>
-            <version>3.5-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>cz.cas.lib.proarc</groupId>
             <artifactId>proarc-mets</artifactId>
-            <version>3.5-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Nejspíš jde o artefakt předchozí verze, nicméně master větev kvůli tomu nejde zbuildit.

Místo tvrdého odkazu na `3.5-SNAPSHOT` nahrazeno proměnnou na `project.version`.